### PR TITLE
Added a contextual feature manager capable of evaluating a feature using an application defined context.

### DIFF
--- a/Microsoft.FeatureManagement.sln
+++ b/Microsoft.FeatureManagement.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28119.50
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29011.400
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureFlagDemo", "examples\FeatureFlagDemo\FeatureFlagDemo.csproj", "{E58A64A6-BE10-4D7A-AAB8-C3E2925CB32F}"
 EndProject
@@ -12,6 +12,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8ED6FFEE-4037-49A2-9709-BC519C104A90}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FeatureManagement.AspNetCore", "src\Microsoft.FeatureManagement.AspNetCore\Microsoft.FeatureManagement.AspNetCore.csproj", "{CFD3E549-2E24-490D-A7F6-F95E56A81092}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{7DF94F12-FA64-4810-AA36-58C14A215A6D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "examples\ConsoleApp\ConsoleApp.csproj", "{FF428691-8288-4866-98D2-47A61177C326}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,12 +39,18 @@ Global
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF428691-8288-4866-98D2-47A61177C326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF428691-8288-4866-98D2-47A61177C326}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF428691-8288-4866-98D2-47A61177C326}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF428691-8288-4866-98D2-47A61177C326}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{E58A64A6-BE10-4D7A-AAB8-C3E2925CB32F} = {7DF94F12-FA64-4810-AA36-58C14A215A6D}
 		{FDBB27BA-C5BA-48A7-BA9B-63159943EA9F} = {8ED6FFEE-4037-49A2-9709-BC519C104A90}
+		{FF428691-8288-4866-98D2-47A61177C326} = {7DF94F12-FA64-4810-AA36-58C14A215A6D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {84DA6C54-F140-4518-A1B4-E4CF42117FBD}

--- a/examples/ConsoleApp/AccountServerContext.cs
+++ b/examples/ConsoleApp/AccountServerContext.cs
@@ -1,0 +1,10 @@
+﻿using Consoto.Banking.AccountServer.FeatureFilters;
+using Microsoft.FeatureManagement;
+
+namespace Consoto.Banking.AccountServer
+{
+    class AccountServerContext : IAccountId, IFeatureFilterContext
+    {
+        public string AccountId { get; set; }
+    }
+}

--- a/examples/ConsoleApp/AccountServerContext.cs
+++ b/examples/ConsoleApp/AccountServerContext.cs
@@ -1,9 +1,12 @@
-﻿using Consoto.Banking.AccountServer.FeatureFilters;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountServer.FeatureFilters;
 using Microsoft.FeatureManagement;
 
 namespace Consoto.Banking.AccountServer
 {
-    class AccountServerContext : IAccountId, IFeatureFilterContext
+    class AccountServerContext : IAccountContext, IFeatureFilterContext
     {
         public string AccountId { get; set; }
     }

--- a/examples/ConsoleApp/ConsoleApp.csproj
+++ b/examples/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Consoto.Banking.AccountServer</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.FeatureManagement\Microsoft.FeatureManagement.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountServer.FeatureFilters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+using System;
+using System.Collections.Generic;
+
+namespace Consoto.Banking.AccountServer.FeatureManagement
+{
+    /// <summary>
+    /// A filter that uses the feature management context to ensure that the current task has the notion of an account id, and that the account id is allowed.
+    /// </summary>
+    [FilterAlias("AccountId")]
+    class AccountIdFilter : IContextualFeatureFilter<IAccountId>
+    {
+        public const string AccountIdKey = "AccountId";
+
+        public bool Evaluate(FeatureFilterEvaluationContext featureEvaluationContext, IAccountId accountId)
+        {
+            if (string.IsNullOrEmpty(accountId?.AccountId))
+            {
+                throw new ArgumentNullException(nameof(accountId));
+            }
+
+            var allowedAccounts = new List<string>();
+
+            featureEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+            return allowedAccounts.Contains(accountId.AccountId);
+        }
+
+        public bool Evaluate(FeatureFilterEvaluationContext context) => false; // No app-context available
+    }
+}

--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -13,11 +13,9 @@ namespace Consoto.Banking.AccountServer.FeatureManagement
     /// A filter that uses the feature management context to ensure that the current task has the notion of an account id, and that the account id is allowed.
     /// </summary>
     [FilterAlias("AccountId")]
-    class AccountIdFilter : IContextualFeatureFilter<IAccountId>
+    class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
     {
-        public const string AccountIdKey = "AccountId";
-
-        public bool Evaluate(FeatureFilterEvaluationContext featureEvaluationContext, IAccountId accountId)
+        public bool Evaluate(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountId)
         {
             if (string.IsNullOrEmpty(accountId?.AccountId))
             {

--- a/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
+++ b/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+
+namespace Consoto.Banking.AccountServer.FeatureFilters
+{
+    public interface IAccountContext : IFeatureFilterContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/examples/ConsoleApp/FeatureFilters/IAccountId.cs
+++ b/examples/ConsoleApp/FeatureFilters/IAccountId.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.FeatureManagement;
-
-namespace Consoto.Banking.AccountServer.FeatureFilters
-{
-    public interface IAccountId : IFeatureFilterContext
-    {
-        string AccountId { get; }
-    }
-}

--- a/examples/ConsoleApp/FeatureFilters/IAccountId.cs
+++ b/examples/ConsoleApp/FeatureFilters/IAccountId.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.FeatureManagement;
+
+namespace Consoto.Banking.AccountServer.FeatureFilters
+{
+    public interface IAccountId : IFeatureFilterContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountServer;
+using Consoto.Banking.AccountServer.FeatureManagement;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.FeatureFilters;
+using System;
+using System.Collections.Generic;
+
+namespace Contoso.Banking.AccountServer
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //
+            // Setup configuration
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            //
+            // Setup application services + feature management
+            IServiceCollection services = new ServiceCollection();
+
+            services.AddSingleton(configuration)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<PercentageFilter>()
+                    .AddFeatureFilter<AccountIdFilter>();
+
+            //
+            // Get the feature manager from application services
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IContextualFeatureManager contextualFeatureManager = serviceProvider.GetRequiredService<IContextualFeatureManager>();
+
+            var accounts = new List<string>()
+            {
+                "abc",
+                "adef",
+                "abcdefghijklmnopqrstuvwxyz"
+            };
+
+            //
+            // Mimic work items in a task-driven console application
+            foreach (var account in accounts)
+            {
+                const string FeatureName = "Beta";
+
+                //
+                // Check if feature enabled
+                //
+                var accountIdContext = new AccountServerContext();
+
+                accountIdContext.AccountId = account;
+
+                bool enabled = contextualFeatureManager.IsEnabled(FeatureName, accountIdContext);
+
+                //
+                // Output results
+                Console.WriteLine($"The {FeatureName} feature is {(enabled ? "enabled" : "disabled")} for the '{account}' account.");
+            }
+        }
+    }
+}

--- a/examples/ConsoleApp/appsettings.json
+++ b/examples/ConsoleApp/appsettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "FeatureManagement": {
+    "Beta": {
+      "EnabledFor": [
+        {
+          "Name": "AccountId",
+          "Parameters": {
+            "AllowedAccounts": [ "abcdefghijklmnopqrstuvwxyz" ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -27,23 +27,19 @@ namespace Microsoft.FeatureManagement
 
             //
             // Extract IContextualFeatureFilter<T>.Evaluate method.
-            IEnumerable<Type> interfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));
+            IEnumerable<Type> contextualFilterInterfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));
 
-            Type cfInterface = interfaces.FirstOrDefault(i => i.GetGenericArguments()[0].IsAssignableFrom(appContextType));
+            Type targetInterface = contextualFilterInterfaces.FirstOrDefault(i => i.GetGenericArguments()[0].IsAssignableFrom(appContextType));
 
-            if (cfInterface != null)
+            if (targetInterface != null)
             {
-                MethodInfo evaluateMethod = cfInterface.GetMethod(nameof(IContextualFeatureFilter<IFeatureFilterContext>.Evaluate), BindingFlags.Public | BindingFlags.Instance);
+                MethodInfo evaluateMethod = targetInterface.GetMethod(nameof(IContextualFeatureFilter<IFeatureFilterContext>.Evaluate), BindingFlags.Public | BindingFlags.Instance);
 
                 _evaluateFunc = TypeAgnosticEvaluate(filter.GetType(), evaluateMethod);
             }
 
             _filter = filter;
-
-            AppContextType = appContextType;
         }
-
-        public Type AppContextType { get; }
 
         public bool Evaluate(FeatureFilterEvaluationContext evaluationContext, IFeatureFilterContext context)
         {
@@ -57,27 +53,33 @@ namespace Microsoft.FeatureManagement
 
         static Func<object, FeatureFilterEvaluationContext, object, bool> TypeAgnosticEvaluate(Type filterType, MethodInfo method)
         {
+            //
             // First fetch the generic form
             MethodInfo genericHelper = typeof(ContextualFeatureFilterEvaluator).GetMethod(nameof(GenericTypeAgnosticEvaluate),
                 BindingFlags.Static | BindingFlags.NonPublic);
 
+            //
             // Now supply the type arguments
             MethodInfo constructedHelper = genericHelper.MakeGenericMethod
                 (filterType, method.GetParameters()[0].ParameterType, method.GetParameters()[1].ParameterType, method.ReturnType);
 
+            //
             // Now call it. The null argument is because it’s a static method.
             object ret = constructedHelper.Invoke(null, new object[] { method });
 
+            //
             // Cast the result to the right kind of delegate and return it
             return (Func<object, FeatureFilterEvaluationContext, object, bool>)ret;
         }
 
         static Func<object, FeatureFilterEvaluationContext, object, bool> GenericTypeAgnosticEvaluate<TTarget, TParam1, TParam2, TReturn>(MethodInfo method)
         {
+            //
             // Convert the slow MethodInfo into a fast, strongly typed, open delegate
             Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool> func = (Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool>)Delegate.CreateDelegate
                 (typeof(Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool>), method);
 
+            //
             // Now create a more weakly typed delegate which will call the strongly typed one
             Func<object, FeatureFilterEvaluationContext, object, bool> ret = (object target, FeatureFilterEvaluationContext param1, object param2) => func((TTarget)target, param1, (TParam2)param2);
 

--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Provides a performance efficient method of evaluating IContextualFeatureFilter&lt;T&gt; without knowing what the generic type parameter is.
+    /// </summary>
+    class ContextualFeatureFilterEvaluator : IContextualFeatureFilter<IFeatureFilterContext>
+    {
+        private IContextualFeatureFilter _filter;
+        private Func<object, FeatureFilterEvaluationContext, object, bool> _evaluateFunc;
+
+        public ContextualFeatureFilterEvaluator(IContextualFeatureFilter filter, Type appContextType)
+        {
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
+
+            if (appContextType == null)
+            {
+                throw new ArgumentNullException(nameof(appContextType));
+            }
+
+            //
+            // Extract IContextualFeatureFilter<T>.Evaluate method.
+            IEnumerable<Type> interfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));
+
+            Type cfInterface = interfaces.FirstOrDefault(i => i.GetGenericArguments()[0].IsAssignableFrom(appContextType));
+
+            if (cfInterface != null)
+            {
+                MethodInfo evaluateMethod = cfInterface.GetMethod(nameof(IContextualFeatureFilter<IFeatureFilterContext>.Evaluate), BindingFlags.Public | BindingFlags.Instance);
+
+                _evaluateFunc = TypeAgnosticEvaluate(filter.GetType(), evaluateMethod);
+            }
+
+            _filter = filter;
+
+            AppContextType = appContextType;
+        }
+
+        public Type AppContextType { get; }
+
+        public bool Evaluate(FeatureFilterEvaluationContext evaluationContext, IFeatureFilterContext context)
+        {
+            if (_evaluateFunc == null)
+            {
+                return false;
+            }
+
+            return _evaluateFunc(_filter, evaluationContext, context);
+        }
+
+        static Func<object, FeatureFilterEvaluationContext, object, bool> TypeAgnosticEvaluate(Type filterType, MethodInfo method)
+        {
+            // First fetch the generic form
+            MethodInfo genericHelper = typeof(ContextualFeatureFilterEvaluator).GetMethod(nameof(GenericTypeAgnosticEvaluate),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            // Now supply the type arguments
+            MethodInfo constructedHelper = genericHelper.MakeGenericMethod
+                (filterType, method.GetParameters()[0].ParameterType, method.GetParameters()[1].ParameterType, method.ReturnType);
+
+            // Now call it. The null argument is because it’s a static method.
+            object ret = constructedHelper.Invoke(null, new object[] { method });
+
+            // Cast the result to the right kind of delegate and return it
+            return (Func<object, FeatureFilterEvaluationContext, object, bool>)ret;
+        }
+
+        static Func<object, FeatureFilterEvaluationContext, object, bool> GenericTypeAgnosticEvaluate<TTarget, TParam1, TParam2, TReturn>(MethodInfo method)
+        {
+            // Convert the slow MethodInfo into a fast, strongly typed, open delegate
+            Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool> func = (Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool>)Delegate.CreateDelegate
+                (typeof(Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool>), method);
+
+            // Now create a more weakly typed delegate which will call the strongly typed one
+            Func<object, FeatureFilterEvaluationContext, object, bool> ret = (object target, FeatureFilterEvaluationContext param1, object param2) => func((TTarget)target, param1, (TParam2)param2);
+
+            return ret;
+        }
+
+        public bool Evaluate(FeatureFilterEvaluationContext context) => false;
+    }
+}

--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -54,33 +57,27 @@ namespace Microsoft.FeatureManagement
         static Func<object, FeatureFilterEvaluationContext, object, bool> TypeAgnosticEvaluate(Type filterType, MethodInfo method)
         {
             //
-            // First fetch the generic form
+            // Get the generic version of the evaluation helper method
             MethodInfo genericHelper = typeof(ContextualFeatureFilterEvaluator).GetMethod(nameof(GenericTypeAgnosticEvaluate),
                 BindingFlags.Static | BindingFlags.NonPublic);
 
             //
-            // Now supply the type arguments
+            // Create a type specific version of the evaluation helper method
             MethodInfo constructedHelper = genericHelper.MakeGenericMethod
                 (filterType, method.GetParameters()[0].ParameterType, method.GetParameters()[1].ParameterType, method.ReturnType);
 
             //
-            // Now call it. The null argument is because it’s a static method.
+            // Invoke the method to get the func
             object ret = constructedHelper.Invoke(null, new object[] { method });
 
-            //
-            // Cast the result to the right kind of delegate and return it
             return (Func<object, FeatureFilterEvaluationContext, object, bool>)ret;
         }
 
         static Func<object, FeatureFilterEvaluationContext, object, bool> GenericTypeAgnosticEvaluate<TTarget, TParam1, TParam2, TReturn>(MethodInfo method)
         {
-            //
-            // Convert the slow MethodInfo into a fast, strongly typed, open delegate
             Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool> func = (Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool>)Delegate.CreateDelegate
                 (typeof(Func<TTarget, FeatureFilterEvaluationContext, TParam2, bool>), method);
 
-            //
-            // Now create a more weakly typed delegate which will call the strongly typed one
             Func<object, FeatureFilterEvaluationContext, object, bool> ret = (object target, FeatureFilterEvaluationContext param1, object param2) => func((TTarget)target, param1, (TParam2)param2);
 
             return ret;

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -167,7 +167,7 @@ namespace Microsoft.FeatureManagement
 
             if (filter is IContextualFeatureFilter contextualFeatureFilter && appContextType != null)
             {
-                ContextualFeatureFilterEvaluator contextualFeatureFilterEvaluator = _contextualFilterCache.GetOrAdd(
+                filter = _contextualFilterCache.GetOrAdd(
                     filterName + "\n" + appContextType.FullName,
                     (_) => contextualFeatureFilter == null ? null : new ContextualFeatureFilterEvaluator(contextualFeatureFilter, appContextType));
             }

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.FeatureManagement
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.FeatureManagement
 {
     /// <summary>
     /// Common interface for all contextual feature filters

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -1,0 +1,27 @@
+﻿namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content.
+    /// Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
+    /// A contextual feature filter can take advantage of contextual data passed in from callers of the feature management system.
+    /// A contextual feature filter will only be executed if a context that is assignable from TContext is available.
+    /// </summary>
+    public interface IContextualFeatureFilter<TContext> : IFeatureFilter, IContextualFeatureFilter where TContext : IFeatureFilterContext
+    {
+        /// <summary>
+        /// Evalutates the feature filter to see if the filter's criteria for being enabled has been satisfied.
+        /// </summary>
+        /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evalute the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
+        /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
+        /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
+        bool Evaluate(FeatureFilterEvaluationContext featureFilterContext, TContext appContext);
+    }
+
+    public interface IContextualFeatureFilter
+    {
+    }
+
+    public interface IFeatureFilterContext
+    {
+    }
+}

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -1,6 +1,13 @@
 ﻿namespace Microsoft.FeatureManagement
 {
     /// <summary>
+    /// Common interface for all contextual feature filters
+    /// </summary>
+    public interface IContextualFeatureFilter
+    {
+    }
+
+    /// <summary>
     /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content.
     /// Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
     /// A contextual feature filter can take advantage of contextual data passed in from callers of the feature management system.
@@ -15,13 +22,5 @@
         /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
         bool Evaluate(FeatureFilterEvaluationContext featureFilterContext, TContext appContext);
-    }
-
-    public interface IContextualFeatureFilter
-    {
-    }
-
-    public interface IFeatureFilterContext
-    {
     }
 }

--- a/src/Microsoft.FeatureManagement/IContextualFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureManager.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.FeatureManagement
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.FeatureManagement
 {
     /// <summary>
     /// Used to evaluate whether a feature is enabled or disabled.

--- a/src/Microsoft.FeatureManagement/IContextualFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureManager.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.FeatureManagement
+{
+    public interface IContextualFeatureManager
+    {
+        /// <summary>
+        /// Checks whether a given feature is enabled.
+        /// </summary>
+        /// <param name="feature">The name of the feature to check.</param>
+        /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
+        /// <returns>True if the feature is enabled, otherwise false.</returns>
+        bool IsEnabled<TContext>(string feature, TContext context) where TContext : IFeatureFilterContext;
+    }
+}

--- a/src/Microsoft.FeatureManagement/IContextualFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureManager.cs
@@ -1,5 +1,8 @@
 ﻿namespace Microsoft.FeatureManagement
 {
+    /// <summary>
+    /// Used to evaluate whether a feature is enabled or disabled.
+    /// </summary>
     public interface IContextualFeatureManager
     {
         /// <summary>

--- a/src/Microsoft.FeatureManagement/IFeatureFilterContext.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilterContext.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.FeatureManagement
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.FeatureManagement
 {
     /// <summary>
     /// Interface for objects that can be used as a context in the feature management system.

--- a/src/Microsoft.FeatureManagement/IFeatureFilterContext.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilterContext.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Interface for objects that can be used as a context in the feature management system.
+    /// </summary>
+    public interface IFeatureFilterContext
+    {
+    }
+}

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.FeatureManagement.FeatureFilters;
 using System;
 
 namespace Microsoft.FeatureManagement
@@ -27,7 +26,11 @@ namespace Microsoft.FeatureManagement
             // Add required services
             services.TryAddSingleton<IFeatureSettingsProvider, ConfigurationFeatureSettingsProvider>();
 
-            services.AddSingleton<IFeatureManager, FeatureManager>();
+            services.TryAddSingleton<FeatureManager, FeatureManager>();
+
+            services.TryAddSingleton<IFeatureManager>(sp => sp.GetRequiredService<FeatureManager>());
+
+            services.TryAddSingleton<IContextualFeatureManager>(sp => sp.GetRequiredService<FeatureManager>());
 
             services.AddSingleton<ISessionManager, EmptySessionManager>();
 

--- a/tests/Tests.FeatureManagement/AppContext.cs
+++ b/tests/Tests.FeatureManagement/AppContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Tests.FeatureManagement
+{
+    class AppContext : IAccountContext
+    {
+        public string AccountId { get; set; }
+    }
+}

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -236,5 +236,31 @@ namespace Tests.FeatureManagement
 
             Assert.True(enabledCount > 0 && enabledCount < 10);
         }
+
+        [Fact]
+        public void UsesContext()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSingleton(config)
+                .AddFeatureManagement()
+                .AddFeatureFilter<TestFilter>();
+
+            ServiceProvider provider = serviceCollection.BuildServiceProvider();
+
+            IContextualFeatureManager featureManager = provider.GetRequiredService<IContextualFeatureManager>();
+
+            AppContext context = new AppContext();
+
+            context.AccountId = "NotEnabledAccount";
+
+            Assert.False(featureManager.IsEnabled(ConditionalFeature, context));
+
+            context.AccountId = "abc";
+
+            Assert.True(featureManager.IsEnabled(ConditionalFeature, context));
+        }
     }
 }

--- a/tests/Tests.FeatureManagement/IAccountContext.cs
+++ b/tests/Tests.FeatureManagement/IAccountContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+
+namespace Tests.FeatureManagement
+{
+    interface IAccountContext : IFeatureFilterContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -1,18 +1,34 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
+using System.Collections.Generic;
 
 namespace Tests.FeatureManagement
 {
-    class TestFilter : IFeatureFilter
+    class TestFilter : IFeatureFilter, IContextualFeatureFilter<IAccountContext>
     {
         public Func<FeatureFilterEvaluationContext, bool> Callback { get; set; }
 
         public bool Evaluate(FeatureFilterEvaluationContext context)
         {
             return Callback?.Invoke(context) ?? false;
+        }
+
+        public bool Evaluate(FeatureFilterEvaluationContext featureFilterEvaluationContext, IAccountContext accountContext)
+        {
+            if (string.IsNullOrEmpty(accountContext?.AccountId))
+            {
+                throw new ArgumentNullException(nameof(accountContext.AccountId));
+            }
+
+            var allowedAccounts = new List<string>();
+
+            featureFilterEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+            return allowedAccounts.Contains(accountContext.AccountId);
         }
     }
 }

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -14,7 +14,10 @@
         {
           "Name": "Test",
           "Parameters": {
-            "P1": "V1"
+            "P1": "V1",
+            "AllowedAccounts": [
+              "abc"
+            ]
           }
         }
       ]


### PR DESCRIPTION
## IContextualFeatureManager

The contextual feature manager is a counterpart to the standard feature manager which is capable of utilizing a application defined context when evaluating the state of a feature. Applications that do not have a notion of an ambient context can pass their own context when evaluating feature state.

### Consumption

The `IContextualFeatureManager` can be obtained all the same ways that `IFeatureManager` can. This includes through dependency injection or by pulling directly from the service collection that feature management was added to.

```
IContextualFeatureManager cfm = services.GetRequiredService<IContextualFeatureManager>();

cfm.IsEnabled("featureName", new MyApplicationContext
{
  UserId = "someUser"
});
```

### Contextual Feature Filters
Contextual feature filters are feature filters that can utilize a context provided by the application when evaluating whether a feature is on or off. All contexts used by contextual feature filters must inherit from `IFeatureFilterContext` to declare intent to be used as a feature filter context. Implementations of contextual feature filters declare the interface that they require the feature filter context to implement to be able to properly handle them.

As an example, `IContextualFeatureFilter<IAccountContext>` requires a context that implements `IAccountContext` to be passed in. If a feature is checked for enabled and a context is provided that does not implement `IAccountContext` then the previously mentioned filter would not run.

