### PR TITLE
Added the capability to pass in a context when checking if a feature is enabled.

### DIFF
--- a/Microsoft.FeatureManagement.sln
+++ b/Microsoft.FeatureManagement.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28119.50
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29011.400
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureFlagDemo", "examples\FeatureFlagDemo\FeatureFlagDemo.csproj", "{E58A64A6-BE10-4D7A-AAB8-C3E2925CB32F}"
 EndProject
@@ -12,6 +12,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8ED6FFEE-4037-49A2-9709-BC519C104A90}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FeatureManagement.AspNetCore", "src\Microsoft.FeatureManagement.AspNetCore\Microsoft.FeatureManagement.AspNetCore.csproj", "{CFD3E549-2E24-490D-A7F6-F95E56A81092}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{FB5C34DF-695C-4DF9-8AED-B3EA2516EA72}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "examples\ConsoleApp\ConsoleApp.csproj", "{E50FB931-7A42-440E-AC47-B8DFE5E15394}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,12 +39,18 @@ Global
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{E58A64A6-BE10-4D7A-AAB8-C3E2925CB32F} = {FB5C34DF-695C-4DF9-8AED-B3EA2516EA72}
 		{FDBB27BA-C5BA-48A7-BA9B-63159943EA9F} = {8ED6FFEE-4037-49A2-9709-BC519C104A90}
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394} = {FB5C34DF-695C-4DF9-8AED-B3EA2516EA72}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {84DA6C54-F140-4518-A1B4-E4CF42117FBD}

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Contextual feature filters implement the `IContextualFeatureFilter<TContext>` in
 
 We can see that the `AccountIdFilter` requires an object that implements `IAccountContext` to be provided to be able to evalute the state of a feature. When using this feature filter, the caller needs to make sure that the passed in object implements `IAccountContext`.
 
+**Note:** Only a single feature filter interface can be implemented by a single type. Trying to add a feature filter that implements more than a single feature filter interface will result in an `ArgumentException`.
+
 ### Built-In Feature Filters
 
 There a few feature filters that come with the `Microsoft.FeatureManagement` package. These feature filters are not added automatically, but can be referenced and registered as soon as the package is registered.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,44 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+## Providing a Context For Feature Evaluation
+
+In console applications there is no ambient context such as `HttpContext` that feature filters can acquire and utilize to check if a feature should be on or off. In this case, applications need to provide an object representing a context into the feature management system for use by feature filters. This is done by using `IFeatureManager.IsEnabledAsync<TContext>(string featureName, TContext appContext)`. The appContext object that is provided to the feature manager can be used by feature filters to evaluate the state of a feature.
+
+```
+  MyAppContext context = new MyAppContext
+  {
+    AccountId = current.Id;
+  }
+
+  if (featureManager.IsEnabled(feature, context))
+  {
+  }
+```
+
+### Contextual Feature Filters
+
+Contextual feature filters implement the `IContextualFeatureFilter<TContext>` interface. These special feature filters can take advantage of the context that is passed in when `IFeatureManager.IsEnabledAsync<TContext>` is called. The `TContext` type parameter in `IContextualFeatureFilter<TContext>` describes what context type the filter is capable of handling. This allows the developer of a contextual feature filter to describe what is required of those who wish to utilize it. Since every type is a descendant of object, a filter that implements `IContextualFeatureFilter<object>` can be called for any provided context. To illustrate an example of a more specific contextual feature filter, consider a feature that is enabled if an account is in a configured list of enabled accounts. 
+
+```    
+  public interface IAccountContext
+  {
+    string AccountId { get; set; }
+  }
+
+  [FilterAlias("AccountId")]
+  class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
+  {
+    public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountId)
+    {
+      //
+      // Evaluate if the feature should be on with the help of the provided IAccountContext
+    }
+  }
+```
+
+We can see that the `AccountIdFilter` requires an object that implements `IAccountContext` to be provided to be able to evalute the state of a feature. When using this feature filter, the caller needs to make sure that the passed in object implements `IAccountContext`.
+
 ### Built-In Feature Filters
 
 There a few feature filters that come with the `Microsoft.FeatureManagement` package. These feature filters are not added automatically, but can be referenced and registered as soon as the package is registered.

--- a/examples/ConsoleApp/AccountServiceContext.cs
+++ b/examples/ConsoleApp/AccountServiceContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountService.FeatureFilters;
+
+namespace Consoto.Banking.AccountService
+{
+    class AccountServiceContext : IAccountContext
+    {
+        public string AccountId { get; set; }
+    }
+}

--- a/examples/ConsoleApp/ConsoleApp.csproj
+++ b/examples/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Consoto.Banking.AccountService</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.FeatureManagement\Microsoft.FeatureManagement.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountService.FeatureFilters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Consoto.Banking.AccountService.FeatureManagement
+{
+    /// <summary>
+    /// A filter that uses the feature management context to ensure that the current task has the notion of an account id, and that the account id is allowed.
+    /// This filter will only be executed if an object implementing <see cref="IAccountContext"/> is passed in during feature evaluation.
+    /// </summary>
+    [FilterAlias("AccountId")]
+    class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
+    {
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountId)
+        {
+            if (string.IsNullOrEmpty(accountId?.AccountId))
+            {
+                throw new ArgumentNullException(nameof(accountId));
+            }
+
+            var allowedAccounts = new List<string>();
+
+            featureEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+            return Task.FromResult(allowedAccounts.Contains(accountId.AccountId));
+        }
+    }
+}

--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -17,18 +17,18 @@ namespace Consoto.Banking.AccountService.FeatureManagement
     [FilterAlias("AccountId")]
     class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountId)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountContext)
         {
-            if (string.IsNullOrEmpty(accountId?.AccountId))
+            if (string.IsNullOrEmpty(accountContext?.AccountId))
             {
-                throw new ArgumentNullException(nameof(accountId));
+                throw new ArgumentNullException(nameof(accountContext));
             }
 
             var allowedAccounts = new List<string>();
 
             featureEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
 
-            return Task.FromResult(allowedAccounts.Contains(accountId.AccountId));
+            return Task.FromResult(allowedAccounts.Contains(accountContext.AccountId));
         }
     }
 }

--- a/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
+++ b/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Consoto.Banking.AccountService.FeatureFilters
+{
+    public interface IAccountContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountService.FeatureManagement;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.FeatureFilters;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Consoto.Banking.AccountService
+{
+    class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            //
+            // Setup configuration
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            //
+            // Setup application services + feature management
+            IServiceCollection services = new ServiceCollection();
+
+            services.AddSingleton(configuration)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<PercentageFilter>()
+                    .AddFeatureFilter<AccountIdFilter>();
+
+            //
+            // Get the feature manager from application services
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            var accounts = new List<string>()
+            {
+                "abc",
+                "adef",
+                "abcdefghijklmnopqrstuvwxyz"
+            };
+
+            //
+            // Mimic work items in a task-driven console application
+            foreach (var account in accounts)
+            {
+                const string FeatureName = "Beta";
+
+                //
+                // Check if feature enabled
+                //
+                var accountServiceContext = new AccountServiceContext
+                {
+                    AccountId = account
+                };
+
+                bool enabled = await featureManager.IsEnabledAsync(FeatureName, accountServiceContext);
+
+                //
+                // Output results
+                Console.WriteLine($"The {FeatureName} feature is {(enabled ? "enabled" : "disabled")} for the '{account}' account.");
+            }
+        }
+    }
+}

--- a/examples/ConsoleApp/appsettings.json
+++ b/examples/ConsoleApp/appsettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "FeatureManagement": {
+    "Beta": {
+      "EnabledFor": [
+        {
+          "Name": "AccountId",
+          "Parameters": {
+            "AllowedAccounts": [ "abcdefghijklmnopqrstuvwxyz" ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Provides a performance efficient method of evaluating IContextualFeatureFilter&lt;T&gt; without knowing what the generic type parameter is.
+    /// </summary>
+    class ContextualFeatureFilterEvaluator : IContextualFeatureFilter<object>
+    {
+        private IFeatureFilterMetadata _filter;
+        private Func<object, FeatureFilterEvaluationContext, object, Task<bool>> _evaluateFunc;
+
+        public ContextualFeatureFilterEvaluator(IFeatureFilterMetadata filter, Type appContextType)
+        {
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
+
+            if (appContextType == null)
+            {
+                throw new ArgumentNullException(nameof(appContextType));
+            }
+
+            Type targetInterface = GetContextualFilterInterface(filter, appContextType);
+
+            //
+            // Extract IContextualFeatureFilter<T>.EvaluateAsync method.
+            if (targetInterface != null)
+            {
+                MethodInfo evaluateMethod = targetInterface.GetMethod(nameof(IContextualFeatureFilter<object>.EvaluateAsync), BindingFlags.Public | BindingFlags.Instance);
+
+                _evaluateFunc = TypeAgnosticEvaluate(filter.GetType(), evaluateMethod);
+            }
+
+            _filter = filter;
+        }
+
+        public static Type GetContextualFilterInterface(IFeatureFilterMetadata filter, Type appContextType)
+        {
+            IEnumerable<Type> contextualFilterInterfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));
+
+            Type targetInterface = null;
+
+            if (contextualFilterInterfaces != null)
+            {
+                targetInterface = contextualFilterInterfaces.FirstOrDefault(i => i.GetGenericArguments()[0].IsAssignableFrom(appContextType));
+            }
+
+            return targetInterface;
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext evaluationContext, object context)
+        {
+            if (_evaluateFunc == null)
+            {
+                return Task.FromResult(false);
+            }
+
+            return _evaluateFunc(_filter, evaluationContext, context);
+        }
+
+        static Func<object, FeatureFilterEvaluationContext, object, Task<bool>> TypeAgnosticEvaluate(Type filterType, MethodInfo method)
+        {
+            //
+            // Get the generic version of the evaluation helper method
+            MethodInfo genericHelper = typeof(ContextualFeatureFilterEvaluator).GetMethod(nameof(GenericTypeAgnosticEvaluate),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            //
+            // Create a type specific version of the evaluation helper method
+            MethodInfo constructedHelper = genericHelper.MakeGenericMethod
+                (filterType, method.GetParameters()[0].ParameterType, method.GetParameters()[1].ParameterType, method.ReturnType);
+
+            //
+            // Invoke the method to get the func
+            object ret = constructedHelper.Invoke(null, new object[] { method });
+
+            return (Func<object, FeatureFilterEvaluationContext, object, Task<bool>>)ret;
+        }
+
+        static Func<object, FeatureFilterEvaluationContext, object, Task<bool>> GenericTypeAgnosticEvaluate<TTarget, TParam1, TParam2, TReturn>(MethodInfo method)
+        {
+            Func<TTarget, FeatureFilterEvaluationContext, TParam2, Task<bool>> func = (Func<TTarget, FeatureFilterEvaluationContext, TParam2, Task<bool>>)Delegate.CreateDelegate
+                (typeof(Func<TTarget, FeatureFilterEvaluationContext, TParam2, Task<bool>>), method);
+
+            Func<object, FeatureFilterEvaluationContext, object, Task<bool>> ret = (object target, FeatureFilterEvaluationContext param1, object param2) => func((TTarget)target, param1, (TParam2)param2);
+
+            return ret;
+        }
+    }
+}

--- a/src/Microsoft.FeatureManagement/FeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementBuilder.cs
@@ -19,15 +19,15 @@ namespace Microsoft.FeatureManagement
 
         public IServiceCollection Services { get; }
 
-        public IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilter
+        public IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilterMetadata
         {
-            Type serviceType = typeof(IFeatureFilter);
+            Type serviceType = typeof(IFeatureFilterMetadata);
 
             Type implementationType = typeof(T);
 
             if (!Services.Any(descriptor => descriptor.ServiceType == serviceType && descriptor.ImplementationType == implementationType))
             {
-                Services.AddSingleton(typeof(IFeatureFilter), typeof(T));
+                Services.AddSingleton(typeof(IFeatureFilterMetadata), typeof(T));
             }
 
             return this;

--- a/src/Microsoft.FeatureManagement/FeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,6 +25,15 @@ namespace Microsoft.FeatureManagement
             Type serviceType = typeof(IFeatureFilterMetadata);
 
             Type implementationType = typeof(T);
+
+            IEnumerable<Type> featureFilterImplementations = implementationType.GetInterfaces()
+                .Where(i => i == typeof(IFeatureFilter) || 
+                            (i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>))));
+
+            if (featureFilterImplementations.Count() > 1)
+            {
+                throw new ArgumentException($"A single feature filter cannot implement more than one feature filter interface.", nameof(T));
+            }
 
             if (!Services.Any(descriptor => descriptor.ServiceType == serviceType && descriptor.ImplementationType == implementationType))
             {

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -16,21 +16,33 @@ namespace Microsoft.FeatureManagement
     class FeatureManager : IFeatureManager
     {
         private readonly IFeatureSettingsProvider _settingsProvider;
-        private readonly IEnumerable<IFeatureFilter> _featureFilters;
+        private readonly IEnumerable<IFeatureFilterMetadata> _featureFilters;
         private readonly IEnumerable<ISessionManager> _sessionManagers;
         private readonly ILogger _logger;
-        private readonly ConcurrentDictionary<string, IFeatureFilter> _filterCache;
+        private readonly ConcurrentDictionary<string, IFeatureFilterMetadata> _filterMetadataCache;
+        private readonly ConcurrentDictionary<string, ContextualFeatureFilterEvaluator> _contextualFeatureFilterCache;
 
-        public FeatureManager(IFeatureSettingsProvider settingsProvider, IEnumerable<IFeatureFilter> featureFilters, IEnumerable<ISessionManager> sessionManagers, ILoggerFactory loggerFactory)
+        public FeatureManager(IFeatureSettingsProvider settingsProvider, IEnumerable<IFeatureFilterMetadata> featureFilters, IEnumerable<ISessionManager> sessionManagers, ILoggerFactory loggerFactory)
         {
             _settingsProvider = settingsProvider;
             _featureFilters = featureFilters ?? throw new ArgumentNullException(nameof(featureFilters));
             _sessionManagers = sessionManagers ?? throw new ArgumentNullException(nameof(sessionManagers));
             _logger = loggerFactory.CreateLogger<FeatureManager>();
-            _filterCache = new ConcurrentDictionary<string, IFeatureFilter>();
+            _filterMetadataCache = new ConcurrentDictionary<string, IFeatureFilterMetadata>();
+            _contextualFeatureFilterCache = new ConcurrentDictionary<string, ContextualFeatureFilterEvaluator>();
         }
 
-        public async Task<bool> IsEnabledAsync(string feature)
+        public Task<bool> IsEnabledAsync(string feature)
+        {
+            return IsEnabledAsync<object>(feature, null, false);
+        }
+
+        public Task<bool> IsEnabledAsync<TContext>(string feature, TContext appContext)
+        {
+            return IsEnabledAsync(feature, appContext, true);
+        }
+
+        private async Task<bool> IsEnabledAsync<TContext>(string feature, TContext appContext, bool useAppContext)
         {
             foreach (ISessionManager sessionManager in _sessionManagers)
             {
@@ -62,7 +74,7 @@ namespace Microsoft.FeatureManagement
 
                     foreach (IFeatureFilterSettings featureFilterSettings in settings.EnabledFor)
                     {
-                        IFeatureFilter filter = GetFeatureFilter(featureFilterSettings.Name);
+                        IFeatureFilterMetadata filter = GetFeatureFilterMetadata(featureFilterSettings.Name);
 
                         if (filter == null)
                         {
@@ -77,11 +89,27 @@ namespace Microsoft.FeatureManagement
                             Parameters = featureFilterSettings.Parameters 
                         };
 
-                        if (await filter.EvaluateAsync(context).ConfigureAwait(false))
+                        //
+                        // IFeatureFilter
+                        if (filter is IFeatureFilter featureFilter && await featureFilter.EvaluateAsync(context).ConfigureAwait(false))
                         {
                             enabled = true;
 
                             break;
+                        }
+                        
+                        //
+                        // IContextualFeatureFilter
+                        if (useAppContext)
+                        {
+                            ContextualFeatureFilterEvaluator contextualFilter = GetContextualFeatureFilter(featureFilterSettings.Name, typeof(TContext));
+
+                            if (contextualFilter != null && await contextualFilter.EvaluateAsync(context, appContext).ConfigureAwait(false))
+                            {
+                                enabled = true;
+
+                                break;
+                            }
                         }
                     }
                 }
@@ -95,15 +123,15 @@ namespace Microsoft.FeatureManagement
             return enabled;
         }
 
-        private IFeatureFilter GetFeatureFilter(string filterName)
+        private IFeatureFilterMetadata GetFeatureFilterMetadata(string filterName)
         {
             const string filterSuffix = "filter";
 
-            IFeatureFilter filter = _filterCache.GetOrAdd(
+            IFeatureFilterMetadata filter = _filterMetadataCache.GetOrAdd(
                 filterName,
                 (_) => {
 
-                    IEnumerable<IFeatureFilter> matchingFilters = _featureFilters.Where(f =>
+                    IEnumerable<IFeatureFilterMetadata> matchingFilters = _featureFilters.Where(f =>
                     {
                         Type t = f.GetType();
 
@@ -140,6 +168,33 @@ namespace Microsoft.FeatureManagement
                     }
 
                     return matchingFilters.FirstOrDefault();
+                }
+            );
+
+            return filter;
+        }
+
+        private ContextualFeatureFilterEvaluator GetContextualFeatureFilter(string filterName, Type appContextType)
+        {
+            if (appContextType == null)
+            {
+                throw new ArgumentNullException(nameof(appContextType));
+            }
+
+            ContextualFeatureFilterEvaluator filter = _contextualFeatureFilterCache.GetOrAdd(
+                $"{filterName}{Environment.NewLine}{appContextType.FullName}",
+                (_) => {
+
+                    IFeatureFilterMetadata metadata = GetFeatureFilterMetadata(filterName);
+
+                    ContextualFeatureFilterEvaluator f = null;
+
+                    if (ContextualFeatureFilterEvaluator.GetContextualFilterInterface(metadata, appContextType) != null)
+                    {
+                        f = new ContextualFeatureFilterEvaluator(metadata, appContextType);
+                    }
+
+                    return f;
                 }
             );
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -187,14 +187,9 @@ namespace Microsoft.FeatureManagement
 
                     IFeatureFilterMetadata metadata = GetFeatureFilterMetadata(filterName);
 
-                    ContextualFeatureFilterEvaluator f = null;
-
-                    if (ContextualFeatureFilterEvaluator.GetContextualFilterInterface(metadata, appContextType) != null)
-                    {
-                        f = new ContextualFeatureFilterEvaluator(metadata, appContextType);
-                    }
-
-                    return f;
+                    return ContextualFeatureFilterEvaluator.IsContextualFilter(metadata, appContextType) ?
+                        new ContextualFeatureFilterEvaluator(metadata, appContextType) :
+                        null;
                 }
             );
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -90,15 +90,6 @@ namespace Microsoft.FeatureManagement
                         };
 
                         //
-                        // IFeatureFilter
-                        if (filter is IFeatureFilter featureFilter && await featureFilter.EvaluateAsync(context).ConfigureAwait(false))
-                        {
-                            enabled = true;
-
-                            break;
-                        }
-                        
-                        //
                         // IContextualFeatureFilter
                         if (useAppContext)
                         {
@@ -110,6 +101,15 @@ namespace Microsoft.FeatureManagement
 
                                 break;
                             }
+                        }
+
+                        //
+                        // IFeatureFilter
+                        if (filter is IFeatureFilter featureFilter && await featureFilter.EvaluateAsync(context).ConfigureAwait(false))
+                        {
+                            enabled = true;
+
+                            break;
                         }
                     }
                 }

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -35,5 +35,21 @@ namespace Microsoft.FeatureManagement
 
             return enabled;
         }
+
+        public async Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
+        {
+            //
+            // First, check local cache
+            if (_flagCache.ContainsKey(feature))
+            {
+                return _flagCache[feature];
+            }
+
+            bool enabled = await _featureManager.IsEnabledAsync(feature, context).ConfigureAwait(false);
+
+            _flagCache[feature] = enabled;
+
+            return enabled;
+        }
     }
 }

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Threading.Tasks;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content.
+    /// Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
+    /// A contextual feature filter can take advantage of contextual data passed in from callers of the feature management system.
+    /// A contextual feature filter will only be executed if a context that is assignable from TContext is available.
+    /// </summary>
+    public interface IContextualFeatureFilter<TContext> : IFeatureFilterMetadata
+    {
+        /// <summary>
+        /// Evalutates the feature filter to see if the filter's criteria for being enabled has been satisfied.
+        /// </summary>
+        /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evalute the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
+        /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
+        /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext);
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.FeatureManagement
     /// <summary>
     /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content. Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
     /// </summary>
-    public interface IFeatureFilter
+    public interface IFeatureFilter : IFeatureFilterMetadata
     {
         /// <summary>
         /// Evalutates the feature filter to see if the filter's criteria for being enabled has been satisfied.

--- a/src/Microsoft.FeatureManagement/IFeatureFilterMetadata.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilterMetadata.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Marker interface for feature filters used to evaluate the state of a feature
+    /// </summary>
+    public interface IFeatureFilterMetadata
+    {
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
@@ -17,7 +17,8 @@ namespace Microsoft.FeatureManagement
 
         /// <summary>
         /// Adds a given feature filter to the list of feature filters that will be available to enable features during runtime.
-        /// /// Possible feature filter metadata types include <see cref="IFeatureFilter"/> and <see cref="IContextualFeatureFilter{TContext}"/>
+        /// Possible feature filter metadata types include <see cref="IFeatureFilter"/> and <see cref="IContextualFeatureFilter{TContext}"/>
+        /// Only one feature filter interface can be implemented by a single type.
         /// </summary>
         /// <typeparam name="T">The feature filter type.</typeparam>
         /// <returns>The feature management builder.</returns>

--- a/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
@@ -17,10 +17,11 @@ namespace Microsoft.FeatureManagement
 
         /// <summary>
         /// Adds a given feature filter to the list of feature filters that will be available to enable features during runtime.
+        /// /// Possible feature filter metadata types include <see cref="IFeatureFilter"/> and <see cref="IContextualFeatureFilter{TContext}"/>
         /// </summary>
         /// <typeparam name="T">The feature filter type.</typeparam>
         /// <returns>The feature management builder.</returns>
-        IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilter;
+        IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilterMetadata;
 
         /// <summary>
         /// Adds an <see cref="ISessionManager"/> to be used for storing feature state in a session.

--- a/src/Microsoft.FeatureManagement/IFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManager.cs
@@ -16,5 +16,13 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to check.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
         Task<bool> IsEnabledAsync(string feature);
+
+        /// <summary>
+        /// Checks whether a given feature is enabled.
+        /// </summary>
+        /// <param name="feature">The name of the feature to check.</param>
+        /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
+        /// <returns>True if the feature is enabled, otherwise false.</returns>
+        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context);
     }
 }

--- a/tests/Tests.FeatureManagement/AppContext.cs
+++ b/tests/Tests.FeatureManagement/AppContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Tests.FeatureManagement
+{
+    class AppContext : IAccountContext
+    {
+        public string AccountId { get; set; }
+    }
+}

--- a/tests/Tests.FeatureManagement/ContextualTestFilter.cs
+++ b/tests/Tests.FeatureManagement/ContextualTestFilter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+using System;
+using System.Threading.Tasks;
+
+namespace Tests.FeatureManagement
+{
+    class ContextualTestFilter : IBla<IAccountContext>
+    {
+        public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        {
+            return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
+        }
+    }
+
+    public interface IBla<T> : IContextualFeatureFilter<T>
+    {
+
+    }
+}

--- a/tests/Tests.FeatureManagement/ContextualTestFilter.cs
+++ b/tests/Tests.FeatureManagement/ContextualTestFilter.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
 {
-    class ContextualTestFilter : IBla<IAccountContext>
+    class ContextualTestFilter : IContextualFeatureFilter<IAccountContext>
     {
         public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
 
@@ -15,10 +15,5 @@ namespace Tests.FeatureManagement
         {
             return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
         }
-    }
-
-    public interface IBla<T> : IContextualFeatureFilter<T>
-    {
-
     }
 }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -248,13 +248,13 @@ namespace Tests.FeatureManagement
 
             serviceCollection.AddSingleton(config)
                 .AddFeatureManagement()
-                .AddFeatureFilter<TestFilter>();
+                .AddFeatureFilter<ContextualTestFilter>();
 
             ServiceProvider provider = serviceCollection.BuildServiceProvider();
 
-            TestFilter testFeatureFilter = (TestFilter)provider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>().First(f => f is TestFilter);
+            ContextualTestFilter contextualTestFeatureFilter = (ContextualTestFilter)provider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>().First(f => f is ContextualTestFilter);
 
-            testFeatureFilter.ContextualCallback = (ctx, accountContext) =>
+            contextualTestFeatureFilter.ContextualCallback = (ctx, accountContext) =>
             {
                 var allowedAccounts = new List<string>();
 
@@ -274,6 +274,28 @@ namespace Tests.FeatureManagement
             context.AccountId = "abc";
 
             Assert.True(await featureManager.IsEnabledAsync(ConditionalFeature, context));
+        }
+
+        [Fact]
+        public void LimitsFeatureFilterImplementations()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var serviceCollection = new ServiceCollection();
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new ServiceCollection().AddSingleton(config)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<InvalidFeatureFilter>();
+            });
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new ServiceCollection().AddSingleton(config)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<InvalidFeatureFilter2>();
+            });
         }
     }
 }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -252,6 +252,17 @@ namespace Tests.FeatureManagement
 
             ServiceProvider provider = serviceCollection.BuildServiceProvider();
 
+            TestFilter testFeatureFilter = (TestFilter)provider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>().First(f => f is TestFilter);
+
+            testFeatureFilter.ContextualCallback = (ctx, accountContext) =>
+            {
+                var allowedAccounts = new List<string>();
+
+                ctx.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+                return allowedAccounts.Contains(accountContext.AccountId);
+            };
+
             IFeatureManager featureManager = provider.GetRequiredService<IFeatureManager>();
 
             AppContext context = new AppContext();

--- a/tests/Tests.FeatureManagement/IAccountContext.cs
+++ b/tests/Tests.FeatureManagement/IAccountContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Tests.FeatureManagement
+{
+    interface IAccountContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
+++ b/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+using System.Threading.Tasks;
+
+namespace Tests.FeatureManagement
+{
+    //
+    // Cannot implement more than one IFeatureFilter interface
+    class InvalidFeatureFilter : IContextualFeatureFilter<IAccountContext>, IContextualFeatureFilter<object>
+    {
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    //
+    // Cannot implement more than one IFeatureFilter interface
+    class InvalidFeatureFilter2 : IFeatureFilter, IContextualFeatureFilter<object>
+    {
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -7,20 +7,13 @@ using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
 {
-    class TestFilter : IFeatureFilter, IContextualFeatureFilter<IAccountContext>
+    class TestFilter : IFeatureFilter
     {
         public Func<FeatureFilterEvaluationContext, bool> Callback { get; set; }
-
-        public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
 
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
         {
             return Task.FromResult(Callback?.Invoke(context) ?? false);
-        }
-
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
-        {
-            return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
         }
     }
 }

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
-using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
@@ -13,23 +11,16 @@ namespace Tests.FeatureManagement
     {
         public Func<FeatureFilterEvaluationContext, bool> Callback { get; set; }
 
+        public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
+
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
         {
             return Task.FromResult(Callback?.Invoke(context) ?? false);
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterEvaluationContext, IAccountContext accountContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
         {
-            if (string.IsNullOrEmpty(accountContext?.AccountId))
-            {
-                throw new ArgumentNullException(nameof(accountContext.AccountId));
-            }
-
-            var allowedAccounts = new List<string>();
-
-            featureFilterEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
-
-            return Task.FromResult(allowedAccounts.Contains(accountContext.AccountId));
+            return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
         }
     }
 }

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -1,19 +1,35 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
 {
-    class TestFilter : IFeatureFilter
+    class TestFilter : IFeatureFilter, IContextualFeatureFilter<IAccountContext>
     {
         public Func<FeatureFilterEvaluationContext, bool> Callback { get; set; }
 
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
         {
             return Task.FromResult(Callback?.Invoke(context) ?? false);
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterEvaluationContext, IAccountContext accountContext)
+        {
+            if (string.IsNullOrEmpty(accountContext?.AccountId))
+            {
+                throw new ArgumentNullException(nameof(accountContext.AccountId));
+            }
+
+            var allowedAccounts = new List<string>();
+
+            featureFilterEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+            return Task.FromResult(allowedAccounts.Contains(accountContext.AccountId));
         }
     }
 }

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -14,7 +14,10 @@
         {
           "Name": "Test",
           "Parameters": {
-            "P1": "V1"
+            "P1": "V1",
+            "AllowedAccounts": [
+              "abc"
+            ]
           }
         }
       ]

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -14,7 +14,12 @@
         {
           "Name": "Test",
           "Parameters": {
-            "P1": "V1",
+            "P1": "V1"
+          }
+        },
+        {
+          "Name": "ContextualTest",
+          "Parameters": {
             "AllowedAccounts": [
               "abc"
             ]


### PR DESCRIPTION
# Passing In Application Context

This PR introduces the capability for applications to pass in a custom context to the feature management system for use in evaluating the state of features. The existing design for this PR is to gather this information from ambient contexts available within the application such as `HttpContext`. The problem with this existing design is that it is not available in console applications and many other frameworks.

### Consumption

The ability to pass a context when evaluating a feature has been added to `IFeatureManager`.

```
IFeatureManager fm = services.GetRequiredService<IFeatureManager>();

fm.IsEnabled("featureName", new MyApplicationContext
{
  UserId = "someUser"
});
```

### Contextual Feature Filters
Contextual feature filters are feature filters that can utilize a context provided by the application when evaluating whether a feature is on or off. Contextual feature filters are a generic type. Their generic type parameter describes the interface that the passed in context must implement for the filter to be able to evaluate it.

As an example, `IContextualFeatureFilter<IAccountContext>` requires a context that implements `IAccountContext` to be passed in. If a feature is checked for enabled and a context is provided that does not implement `IAccountContext` then the previously mentioned filter would not run.

An `IContextualFeatureFilter<object>` would be able to handle any passed in context.

### IFeatureFilterMetadata

With the introduction of `IContextualFeatureFilter` there are now two types of feature filters including `IFeatureFilter`. The two types of feature filters both inherit `IFeatureFilterMetadata`. `IFeatureFilterMetadata` is a marker interface and does not actually provide any feature filtering capabilities. It is used as the new parameter type for `IFeatureManagementBuilder.AddFeatureFilter`.