### PR TITLE
Added reading feature flag config from Azure AppConfig

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureSettingsProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureSettingsProvider.cs
@@ -106,10 +106,21 @@ namespace Microsoft.FeatureManagement
         private IConfigurationSection GetFeatureConfiguration(string featureName)
         {
             const string FeatureManagementSectionName = "FeatureManagement";
+            const string AzureAppConfigPrefix = ".appconfig.featureflag/";
 
             //
             // Look for settings under the "FeatureManagement" section
             IConfigurationSection featureConfiguration = _configuration.GetSection(FeatureManagementSectionName).GetChildren().FirstOrDefault(section => section.Key.Equals(featureName, StringComparison.OrdinalIgnoreCase));
+
+            //
+            // Check if there is any Azure AppConfig feature flag
+            // WARNING!
+            // This is according to the PREVIEW code as documented here:
+            // https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-app-configuration/manage-feature-flags.md
+            if (featureConfiguration == null)
+            {
+                featureConfiguration = _configuration.GetSection(AzureAppConfigPrefix + featureName);
+            }
 
             //
             // Fallback to the configuration section using the feature's name

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -26,5 +26,18 @@
         }
       ]
     }
+  },
+
+  ".appconfig.featureflag/TestAzureAppConfigOnFeature": true,
+  ".appconfig.featureflag/TestAzureAppConfigOffFeature": false,
+  ".appconfig.featureflag/TestAzureAppConfigConditionalFeature": {
+    "EnabledFor": [
+      {
+        "Name": "Test",
+        "Parameters": {
+          "P1": "V1"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
Updated the `ConfigurationFeatureSettingsProvider.GetFeatureConfiguration` to try reading the Azure AppConfig key name, so this library can be used with Azure AppConfig features.

More info:
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-app-configuration/manage-feature-flags.md

**WARNING!**
Azure AppConfig is still in **preview**!
I.e. this code works, but how feature flags are stored may change.