### PR TITLE
Added feature settings caching.

### DIFF
--- a/examples/FeatureFlagDemo/FeatureFlagDemo.csproj
+++ b/examples/FeatureFlagDemo/FeatureFlagDemo.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="1.0.0-preview-008920001-990" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="3.0.0-preview-010560002-1165" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/FeatureFlagDemo/Program.cs
+++ b/examples/FeatureFlagDemo/Program.cs
@@ -3,6 +3,7 @@
 //
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 
 namespace FeatureFlagDemo
@@ -29,7 +30,7 @@ namespace FeatureFlagDemo
                         {
                             o.Connect(settings["AppConfiguration:ConnectionString"]);
 
-                            o.Use(KeyFilter.Any);
+                            o.Select(KeyFilter.Any);
 
                             o.UseFeatureFlags();
                         });

--- a/examples/FeatureFlagDemo/Startup.cs
+++ b/examples/FeatureFlagDemo/Startup.cs
@@ -63,6 +63,8 @@ namespace FeatureFlagDemo
                 app.UseHsts();
             }
 
+            app.UseAzureAppConfiguration();
+
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCookiePolicy();

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureSettingsProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureSettingsProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.FeatureManagement
         private const string FeatureFiltersSectionName = "EnabledFor";
         private readonly IConfiguration _configuration;
         private readonly ConcurrentDictionary<string, IFeatureSettings> _settings;
-        private readonly IDisposable _changeSubscription;
+        private IDisposable _changeSubscription;
         private int _stale = 0;
 
         public ConfigurationFeatureSettingsProvider(IConfiguration configuration)
@@ -34,7 +34,9 @@ namespace Microsoft.FeatureManagement
 
         public void Dispose()
         {
-            _changeSubscription.Dispose();
+            _changeSubscription?.Dispose();
+
+            _changeSubscription = null;
         }
 
         public IFeatureSettings TryGetFeatureSettings(string featureName)


### PR DESCRIPTION
A perf analysis of the library pointed out a bottle neck in the feature management pipeline during obtaining feature settings. This is due to the fact that sections in the .NET Core configuration were being enumerated on every lookup.

The `ConfigurationFeatureSettingsProvider` has been improved to cache feature settings when they have been read from the .NET Core configuration system. The `IConfiguration`'s reload token is used to track when the configuration has become stale.

`ConfigurationFeatureSettingsProvider` now implements `IDisposable` since it registers a callback on a reload token. The disposable of this will happen when the service container is disposed.