### PR TITLE
Throw an exception if a configured feature filter has not been registered (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,15 @@ Creating a feature filter provides a way to enable features based on criteria th
 
 Feature filters are registered by the `IFeatureManagementBuilder` when `AddFeatureManagement` is called. These feature filters have access to the services that exist within the service collection that was used to add feature flags. Dependency injection can be used to retrieve these services.
 
+If a feature is configured to be enabled for a specific feature filter and the feature hasn't been registered, an exception will be thrown when the feature will be evaluated. The exception could be silently swallowed, using the feature manager's options. 
+
+```
+services.Configure<FeatureManagerOptions>(options =>
+{
+    options.SwallowExceptionForUnregisteredFilter = true;
+});
+```
+
 ### Parameterized Feature Filters
 
 Some feature filters require parameters to decide whether a feature should be turned on or not. For example a browser feature filter may turn on a feature for a certain set of browsers. It may be desired that Edge and Chrome browsers enable a feature, while FireFox does not. To do this a feature filter can be designed to expect parameters. These parameters would be specified in the feature configuration, and in code would be accessible via the `FeatureFilterEvaluationContext` parameter of `IFeatureFilter.EvaluateAsync`.

--- a/src/Microsoft.FeatureManagement/FeatureManagerOptions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerOptions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Options that are being used when a feature is being evaluated by the Feature Manager.
+    /// </summary>
+    public class FeatureManagerOptions
+    {
+        /// <summary>
+        /// Is being used to decide if an exception should be thrown or not when a configured feature filter has not been registered.
+        /// </summary>
+        public bool SwallowExceptionForUnregisteredFilter { get; set; }
+    }
+}


### PR DESCRIPTION
If a feature is configured to be enabled for a specific feature filter and the feature hasn't been registered, an exception will be thrown when the feature will be evaluated. The exception could be silently swallowed, using the feature manager's options.  