### PR TITLE
Updated feature manager to throw FeatureManagementException instead of InvalidOperationException.

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -8,6 +8,11 @@
         /// <summary>
         /// A feature filter that was listed for feature evaluation was not found.
         /// </summary>
-        MissingFeatureFilter
+        MissingFeatureFilter,
+
+        /// <summary>
+        /// Multiple feature filters match the name listed for feature evaluation.
+        /// </summary>
+        ConflictingFeatureFilter
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -11,8 +11,8 @@
         MissingFeatureFilter,
 
         /// <summary>
-        /// Multiple feature filters match the name listed for feature evaluation.
+        /// A feature filter configured for the feature being evaluated is an ambiguous reference to multiple registered feature filters.
         /// </summary>
-        ConflictingFeatureFilter
+        AmbiguousFeatureFilter
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.FeatureManagement
 
                     if (matchingFilters.Count() > 1)
                     {
-                        throw new InvalidOperationException($"Multiple feature filters match the configured filter named '{filterName}'.");
+                        throw new FeatureManagementException(FeatureManagementError.ConflictingFeatureFilter, $"Multiple feature filters match the configured filter named '{filterName}'.");
                     }
 
                     return matchingFilters.FirstOrDefault();

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.FeatureManagement
 
                     if (matchingFilters.Count() > 1)
                     {
-                        throw new FeatureManagementException(FeatureManagementError.ConflictingFeatureFilter, $"Multiple feature filters match the configured filter named '{filterName}'.");
+                        throw new FeatureManagementException(FeatureManagementError.AmbiguousFeatureFilter, $"Multiple feature filters match the configured filter named '{filterName}'.");
                     }
 
                     return matchingFilters.FirstOrDefault();


### PR DESCRIPTION
Currently, the feature manager throws an `InvalidOperationException` in the event that multiple feature filters match a name provided in the feature's filter list. The InvalidOperationException constitutes an error that doesn't really make sense for this type of problem. 

Now that we have the `FeatureManagementException` we can propogate the correct error, `AmbigousFeatureFilter`.