### PR TITLE
Make missing feature filter test clearer

### DIFF
--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -337,6 +337,12 @@ namespace Tests.FeatureManagement
             var services = new ServiceCollection();
 
             services
+                .Configure<FeatureManagementOptions>(options =>
+                {
+                    options.IgnoreMissingFeatureFilters = false;
+                });
+
+            services
                 .AddSingleton(config)
                 .AddFeatureManagement();
 


### PR DESCRIPTION
Looking through this test and there's a bunch of implied knowledge that's required which isn't immediately obvious. This PR fixes that (though that's assuming you'd rather test the default behaviour as opposed to explicitly setting the `IgnoreMissingFeatureFilters` property to `false`).