### PR TITLE
Updated build pipeline to use .NET Core 3.1 sdk.

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -3,7 +3,7 @@ environment:
     os: windows
   runtime:
     provider: appcontainer
-    image: microsoft/dotnet:2.1-sdk
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1
   
 restore:
   commands:
@@ -26,7 +26,7 @@ build:
         - from: 'src'
           to: 'Binaries'
           include:
-            - '*/bin/BuildOutput/**/*'
+            - '*/bin/Release/**/*'
 
 package:
   commands:

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,8 @@
-call %~dp0build\InstallPowerShellCore.cmd
+call %~dp0build\ChoosePowerShell.cmd
 
-%PowerShellCore% "%~dp0build.ps1" %*
+IF %ERRORLEVEL% NEQ 0 (
+
+    exit /B 1
+)
+
+%PowerShell% "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -35,7 +35,7 @@ if ($RestoreOnly)
 else
 {
     # Build
-    dotnet build -c $BuildConfig "$Solution" /p:OutDir=$BuildRelativePath | Tee-Object -FilePath "$LogDirectory\build.log"
+    dotnet build -c $BuildConfig "$Solution" | Tee-Object -FilePath "$LogDirectory\build.log"
 }
 
 exit $LASTEXITCODE

--- a/build.ps1
+++ b/build.ps1
@@ -18,7 +18,6 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$BuildRelativePath = "bin\BuildOutput"
 $LogDirectory = "$PSScriptRoot\buildlogs"
 $Solution     = "$PSScriptRoot\Microsoft.FeatureManagement.sln"
 

--- a/build/ChoosePowerShell.cmd
+++ b/build/ChoosePowerShell.cmd
@@ -1,0 +1,23 @@
+:: where.exe does not exist in windows container, application specific test must be used to check for existence
+
+PowerShell -Command Write-Host "a"
+
+IF %ERRORLEVEL% == 0 (
+
+    set PowerShell=PowerShell
+
+    exit /B 0
+)
+
+pwsh -Command Write-Host "a"
+
+IF %ERRORLEVEL% == 0 (
+
+    set PowerShell=pwsh
+
+    exit /B 0
+)
+
+echo Could not find a suitable PowerShell executable.
+
+EXIT /B 1

--- a/build/ChoosePowerShell.cmd
+++ b/build/ChoosePowerShell.cmd
@@ -1,19 +1,19 @@
 :: where.exe does not exist in windows container, application specific test must be used to check for existence
 
-PowerShell -Command Write-Host "a"
-
-IF %ERRORLEVEL% == 0 (
-
-    set PowerShell=PowerShell
-
-    exit /B 0
-)
-
 pwsh -Command Write-Host "a"
 
 IF %ERRORLEVEL% == 0 (
 
     set PowerShell=pwsh
+
+    exit /B 0
+)
+
+PowerShell -Command Write-Host "a"
+
+IF %ERRORLEVEL% == 0 (
+
+    set PowerShell=PowerShell
 
     exit /B 0
 )

--- a/build/InstallPowerShellCore.cmd
+++ b/build/InstallPowerShellCore.cmd
@@ -1,5 +1,0 @@
-if not exist "%USERPROFILE%\.dotnet\tools\pwsh.exe" (
-  dotnet tool install --global PowerShell --version 6.2.3
-)
-
-set PowerShellCore="%USERPROFILE%\.dotnet\tools\pwsh.exe"

--- a/pack.cmd
+++ b/pack.cmd
@@ -1,3 +1,8 @@
-call %~dp0build\InstallPowerShellCore.cmd
+call %~dp0build\ChoosePowerShell.cmd
 
-%PowerShellCore% "%~dp0pack.ps1" %*
+IF %ERRORLEVEL% NEQ 0 (
+
+    exit /B 1
+)
+
+%PowerShell% "%~dp0pack.ps1" %*

--- a/pack.ps1
+++ b/pack.ps1
@@ -8,11 +8,13 @@ Note: build.cmd should be run before running this script.
 
 [CmdletBinding()]
 param(
+    [Parameter()]
+    [ValidateSet('Debug','Release')]
+    [string]$BuildConfig = "Release"
 )
 
 $ErrorActionPreference = "Stop"
 
-$PrebuiltBinariesDir = "bin\BuildOutput"
 $PublishRelativePath = "bin\PackageOutput"
 $LogDirectory = "$PSScriptRoot\buildlogs"
 
@@ -32,9 +34,7 @@ foreach ($project in $targetProjects)
     $projectPath = "$PSScriptRoot\src\$project\$project.csproj"
     $outputPath = "$PSScriptRoot\src\$project\$PublishRelativePath"
 
-    #
-    # The build system expects pre-built binaries to be in the folder pointed to by 'OutDir'.
-    dotnet pack -o "$outputPath" /p:OutDir=$PrebuiltBinariesDir "$projectPath" --no-build | Tee-Object -FilePath "$LogDirectory\build.log"
+    dotnet pack -c $BuildConfig -o "$outputPath" "$projectPath" --no-build | Tee-Object -FilePath "$LogDirectory\build.log"
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
The change to target multiple frameworks resulted in a couple required changes to get build and pack working as expected.

* Use .NET Core 3.1 sdk container image
* Remove output path specification from build/pack command
  * This causes the builds for each target framework to overwrite one another resulting in build errors and mispackaged binaries
* Updated build and pack to determine what PowerShell should be used
  * .NET Core 3.1 container image comes with `pwsh` built-in