### PR TITLE
Proposed fix for FeatureManagerSnapshot's 'one flag, many contexts' problem.

### DIFF
--- a/examples/ConsoleApp/AccountServiceContext.cs
+++ b/examples/ConsoleApp/AccountServiceContext.cs
@@ -8,5 +8,19 @@ namespace Consoto.Banking.AccountService
     class AccountServiceContext : IAccountContext
     {
         public string AccountId { get; set; }
+        
+        public string ID { get; private set; }
+
+        /// <summary>
+        /// Creates feature context.
+        /// </summary>
+        /// <param name="id">
+        /// Feature context identifier.
+        /// Optional if contexts are not required to be unique.
+        /// </param>
+        public AccountServiceContext(string id = null)
+        {
+            ID = id;
+        }
     }
 }

--- a/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
+++ b/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+
+using Microsoft.FeatureManagement;
+
 namespace Consoto.Banking.AccountService.FeatureFilters
 {
-    public interface IAccountContext
+    public interface IAccountContext : IFeatureContext
     {
         string AccountId { get; }
     }

--- a/src/Microsoft.FeatureManagement/FeatureContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureContext.cs
@@ -1,0 +1,27 @@
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Context used to evaluate feature flags.
+    /// </summary>
+    public class FeatureContext : IFeatureContext
+    {
+        /// <summary>
+        /// Context ID.
+        /// Used to determine uniqueness of a context.
+        /// Generated and provided by the caller. 
+        /// </summary>
+        public string ID { get; private set; }
+
+        /// <summary>
+        /// Creates feature context.
+        /// </summary>
+        /// <param name="id">
+        /// Feature context identifier.
+        /// Optional if contexts are not required to be unique.
+        /// </param>
+        public FeatureContext(string id = null)
+        {
+            ID = id;
+        }
+    }
+}

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -14,6 +15,10 @@ namespace Microsoft.FeatureManagement
     {
         private readonly IFeatureManager _featureManager;
         private readonly IDictionary<string, bool> _flagCache = new Dictionary<string, bool>();
+
+        private readonly IDictionary<(string, string), bool> _flagContextCache =
+            new Dictionary<(string, string), bool>();
+
         private IEnumerable<string> _featureNames;
 
         public FeatureManagerSnapshot(IFeatureManager featureManager)
@@ -57,18 +62,18 @@ namespace Microsoft.FeatureManagement
             return enabled;
         }
 
-        public async Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
+        public async Task<bool> IsEnabledAsync(string feature, IFeatureContext context)
         {
             //
             // First, check local cache
-            if (_flagCache.ContainsKey(feature))
+            if (_flagContextCache.ContainsKey((feature, context.ID)))
             {
-                return _flagCache[feature];
+                return _flagContextCache[(feature, context.ID)];
             }
 
             bool enabled = await _featureManager.IsEnabledAsync(feature, context).ConfigureAwait(false);
 
-            _flagCache[feature] = enabled;
+            _flagContextCache[(feature, context.ID)] = enabled;
 
             return enabled;
         }

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -11,14 +11,14 @@ namespace Microsoft.FeatureManagement
     /// A contextual feature filter can take advantage of contextual data passed in from callers of the feature management system.
     /// A contextual feature filter will only be executed if a context that is assignable from TContext is available.
     /// </summary>
-    public interface IContextualFeatureFilter<TContext> : IFeatureFilterMetadata
+    public interface IContextualFeatureFilter<T> : IFeatureFilterMetadata where T : IFeatureContext
     {
         /// <summary>
         /// Evaluates the feature filter to see if the filter's criteria for being enabled has been satisfied.
         /// </summary>
         /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
-        /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
+        /// <param name="featureContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
-        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext);
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, T featureContext);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureContext.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureContext.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Common interface for all feature contexts.
+    /// </summary>
+    public interface IFeatureContext
+    {
+        /// <summary>
+        /// Context ID.
+        /// Used to determine uniqueness of a context.
+        /// Generated and provided by the caller. 
+        /// </summary>
+        string ID { get; }
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManager.cs
@@ -30,6 +30,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to check.</param>
         /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context);
+        Task<bool> IsEnabledAsync(string feature, IFeatureContext context);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManagerSnapshot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+
 namespace Microsoft.FeatureManagement
 {
     /// <summary>

--- a/src/Microsoft.FeatureManagement/Targeting/ITargetingContext.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ITargetingContext.cs
@@ -8,7 +8,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     /// <summary>
     /// Contextual information that is required to perform a targeting evaluation.
     /// </summary>
-    public interface ITargetingContext
+    public interface ITargetingContext : IFeatureContext
     {
         /// <summary>
         /// The user id that should be considered when evaluating if the context is being targeted.

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingContext.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingContext.cs
@@ -19,5 +19,24 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// The groups that should be considered when evaluating if the context is being targeted.
         /// </summary>
         public IEnumerable<string> Groups { get; set; }
+
+        /// <summary>
+        /// Context ID.
+        /// Used to determine uniqueness of a context.
+        /// Generated and provided by the caller. 
+        /// </summary>
+        public string ID { get; private set; }
+
+        /// <summary>
+        /// Creates feature context.
+        /// </summary>
+        /// <param name="id">
+        /// Feature context identifier.
+        /// Optional if contexts are not required to be unique.
+        /// </param>
+        public TargetingContext(string id = null)
+        {
+            ID = id;
+        }
     }
 }

--- a/tests/Tests.FeatureManagement/AppContext.cs
+++ b/tests/Tests.FeatureManagement/AppContext.cs
@@ -6,5 +6,19 @@ namespace Tests.FeatureManagement
     class AppContext : IAccountContext
     {
         public string AccountId { get; set; }
+        
+        public string ID { get; private set; }
+
+        /// <summary>
+        /// Creates feature context.
+        /// </summary>
+        /// <param name="id">
+        /// Feature context identifier.
+        /// Optional if contexts are not required to be unique.
+        /// </param>
+        public AppContext(string id = null)
+        {
+            ID = id;
+        }
     }
 }

--- a/tests/Tests.FeatureManagement/IAccountContext.cs
+++ b/tests/Tests.FeatureManagement/IAccountContext.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+
+using Microsoft.FeatureManagement;
+
 namespace Tests.FeatureManagement
 {
-    interface IAccountContext
+    interface IAccountContext : IFeatureContext
     {
         string AccountId { get; }
     }

--- a/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
+++ b/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
@@ -8,14 +8,14 @@ namespace Tests.FeatureManagement
 {
     //
     // Cannot implement more than one IFeatureFilter interface
-    class InvalidFeatureFilter : IContextualFeatureFilter<IAccountContext>, IContextualFeatureFilter<object>
+    class InvalidFeatureFilter : IContextualFeatureFilter<IAccountContext>, IContextualFeatureFilter<IFeatureContext>
     {
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
         {
             return Task.FromResult(false);
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, IFeatureContext featureContext)
         {
             return Task.FromResult(false);
         }
@@ -23,9 +23,9 @@ namespace Tests.FeatureManagement
 
     //
     // Cannot implement more than one IFeatureFilter interface
-    class InvalidFeatureFilter2 : IFeatureFilter, IContextualFeatureFilter<object>
+    class InvalidFeatureFilter2 : IFeatureFilter, IContextualFeatureFilter<IFeatureContext>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, IFeatureContext featureContext)
         {
             return Task.FromResult(false);
         }


### PR DESCRIPTION
Proposed fix for:

https://github.com/microsoft/FeatureManagement-Dotnet/issues/87

What happens in this change is:

* I think `FeatureManagerSnapshot`'s cache needs to be aware of the context in which individual flags were evaluated:
  * if a flag `A` was evaluated in context identified as `B`, every subsequent `A` evaluation for contexts identified as `B` should yield the same results, therefore such evaluations (feature name + context) are good candidates to be cached
  * if a flag `A` is evaluated in context identified as `C` for the first time, there should be no cache results for such evaluation (yet). Instead, flag `A` should be evaluated in context `C` and the result should be cached.
* I left `FeatureManagerSnapshot`'s `_flagCache` untouched. Callers evaluating flags without a context should have a separate cache, independent of contextual evaluations.
* I introduced `private readonly IDictionary<(string, string), bool> _flagContextCache;` as a way of storing contextual flag evaluations. The tuple key is:
  * feature name
  * feature context identifier
* I replaced unrestricted `TContext` with `IFeatureContext` which allows its users to assign identifiers to their feature contexts (allows but not forces to - context identifiers are optional as they are not essential for e.g. `FeatureManager` usage). Identifiable/unique contexts can serve as cache keys in `_flagContextCache`. How the feature context identifiers are generated is left to caller's discretion. In the tests I introduced, those identifiers are simply `AccountId` strings, but can be made arbitrarily complex or simple, depending on the requirement.
* I renamed `application context` to `feature context` as the contexts shouldn't probably be associated with an application. In a sense that there can be many different feature evaluation contexts per application and they probably shouldn't all be called `application context`.
