### PR TITLE
Fixed issue with the captive dependency

### DIFF
--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.FeatureManagement
             // Add required services
             services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
 
-            services.AddSingleton<IFeatureManager, FeatureManager>();
+            services.AddScoped<IFeatureManager, FeatureManager>();
 
             services.AddSingleton<ISessionManager, EmptySessionManager>();
 


### PR DESCRIPTION
I stumbled with the issue during the implementation of my custom `IFeatureDefinitionProvider`.

For `CustomFeatureDefinitionProvider : IFeatureDefinitionProvider` I need to retrieve the list of available features from the feature database. `IFeatureManager` registered as a singleton, it cause an issue with the `DbContext` injection. `CustomFeatureDefinitionProvider` registered as scoped, but `DbContext` in `CustomFeatureDefinitionProvider` injected from Application Root Scope instead of Request Scope, which is not correct (`DbContext` acts like a singleton in this case, even if its lifetime defined as Scoped in the `Startup`).

Registering `IFeatureManager` with the Scoped lifetime allow us to avoid the captive dependency issue, when IoC-container use wrong (base(application root) instead of current(request)) scope for the instantiation of services.