### PR TITLE
Remove package source with missing config file

### DIFF
--- a/.pipelines/pipeline.user.yml
+++ b/.pipelines/pipeline.user.yml
@@ -16,9 +16,3 @@ static_analysis_options:
       - exclude:
           - 'examples/**/*.*'
           - 'tests/**/*.*'
-
-package_sources:
-  nuget:
-    config_files:
-      - include:
-          - "NuGet.Config"


### PR DESCRIPTION
This pull request removes the unused reference to the configuration file for NuGet package sources.