### PR TITLE
Add NuGet.config with public feed as package source

### DIFF
--- a/.pipelines/pipeline.user.yml
+++ b/.pipelines/pipeline.user.yml
@@ -16,3 +16,9 @@ static_analysis_options:
       - exclude:
           - 'examples/**/*.*'
           - 'tests/**/*.*'
+
+package_sources:
+  nuget:
+    config_files:
+      - include:
+          - "NuGet.Config"

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This pull request adds NuGet.config with public feed as package source. This will allow packages to be fetched from this source even when no default path is configured.