### PR TITLE
Add cancellation token parameter to async feature management interfaces.

### DIFF
--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Consoto.Banking.AccountService.FeatureManagement
@@ -17,7 +18,7 @@ namespace Consoto.Banking.AccountService.FeatureManagement
     [FilterAlias("AccountId")]
     class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountContext, CancellationToken _)
         {
             if (string.IsNullOrEmpty(accountContext?.AccountId))
             {

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.FeatureManagement;
 using Microsoft.FeatureManagement.FeatureFilters;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Consoto.Banking.AccountService
@@ -58,7 +59,7 @@ namespace Consoto.Banking.AccountService
                         AccountId = account
                     };
 
-                    bool enabled = await featureManager.IsEnabledAsync(FeatureName, accountServiceContext);
+                    bool enabled = await featureManager.IsEnabledAsync(FeatureName, accountServiceContext, CancellationToken.None);
 
                     //
                     // Output results

--- a/examples/FeatureFlagDemo/BrowserFilter.cs
+++ b/examples/FeatureFlagDemo/BrowserFilter.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FeatureFlagDemo.FeatureManagement.FeatureFilters
@@ -23,7 +24,7 @@ namespace FeatureFlagDemo.FeatureManagement.FeatureFilters
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
         {
             BrowserFilterSettings settings = context.Parameters.Get<BrowserFilterSettings>() ?? new BrowserFilterSettings();
 

--- a/examples/FeatureFlagDemo/Controllers/HomeController.cs
+++ b/examples/FeatureFlagDemo/Controllers/HomeController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.FeatureManagement;
 using Microsoft.FeatureManagement.Mvc;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace FeatureFlagDemo.Controllers
 {
@@ -26,11 +27,11 @@ namespace FeatureFlagDemo.Controllers
             return View();
         }
 
-        public async Task<IActionResult> About()
+        public async Task<IActionResult> About(CancellationToken cancellationToken)
         {
             ViewData["Message"] = "Your application description page.";
 
-            if (await _featureManager.IsEnabledAsync(nameof(MyFeatureFlags.CustomViewData)))
+            if (await _featureManager.IsEnabledAsync(nameof(MyFeatureFlags.CustomViewData), cancellationToken))
             {
                 ViewData["Message"] = $"This is FANCY CONTENT you can see only if '{nameof(MyFeatureFlags.CustomViewData)}' is enabled.";
             };

--- a/examples/FeatureFlagDemo/HttpContextTargetingContextAccessor.cs
+++ b/examples/FeatureFlagDemo/HttpContextTargetingContextAccessor.cs
@@ -6,6 +6,7 @@ using Microsoft.FeatureManagement.FeatureFilters;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FeatureFlagDemo
@@ -23,7 +24,7 @@ namespace FeatureFlagDemo
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         }
 
-        public ValueTask<TargetingContext> GetContextAsync()
+        public ValueTask<TargetingContext> GetContextAsync(CancellationToken _)
         {
             HttpContext httpContext = _httpContextAccessor.HttpContext;
 

--- a/examples/FeatureFlagDemo/SuperUserFilter.cs
+++ b/examples/FeatureFlagDemo/SuperUserFilter.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license.
 //
 using Microsoft.FeatureManagement;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FeatureFlagDemo.FeatureManagement.FeatureFilters
 {
     public class SuperUserFilter : IFeatureFilter
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
         {
             return Task.FromResult(false);
         }

--- a/examples/TargetingConsoleApp/Program.cs
+++ b/examples/TargetingConsoleApp/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.FeatureManagement.FeatureFilters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Consoto.Banking.HelpDesk
@@ -62,7 +63,7 @@ namespace Consoto.Banking.HelpDesk
                         Groups = user.Groups
                     };
 
-                    bool enabled = await featureManager.IsEnabledAsync(FeatureName, targetingContext);
+                    bool enabled = await featureManager.IsEnabledAsync(FeatureName, targetingContext, CancellationToken.None);
 
                     //
                     // Output results

--- a/src/Microsoft.FeatureManagement.AspNetCore/FeatureGateAttribute.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/FeatureGateAttribute.cs
@@ -106,8 +106,8 @@ namespace Microsoft.FeatureManagement.Mvc
             //
             // Enabled state is determined by either 'any' or 'all' features being enabled.
             bool enabled = RequirementType == RequirementType.All ?
-                             await Features.All(async feature => await fm.IsEnabledAsync(feature).ConfigureAwait(false)) :
-                             await Features.Any(async feature => await fm.IsEnabledAsync(feature).ConfigureAwait(false));
+                             await Features.All(async feature => await fm.IsEnabledAsync(feature, context.HttpContext.RequestAborted).ConfigureAwait(false)).ConfigureAwait(false) :
+                             await Features.Any(async feature => await fm.IsEnabledAsync(feature, context.HttpContext.RequestAborted).ConfigureAwait(false)).ConfigureAwait(false);
 
             if (enabled)
             {

--- a/src/Microsoft.FeatureManagement.AspNetCore/FeatureGatedAsyncActionFilter.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/FeatureGatedAsyncActionFilter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.FeatureManagement
         {
             IFeatureManager featureManager = context.HttpContext.RequestServices.GetRequiredService<IFeatureManagerSnapshot>();
 
-            if (await featureManager.IsEnabledAsync(FeatureName).ConfigureAwait(false))
+            if (await featureManager.IsEnabledAsync(FeatureName, context.HttpContext.RequestAborted).ConfigureAwait(false))
             {
                 IServiceProvider serviceProvider = context.HttpContext.RequestServices.GetRequiredService<IServiceProvider>();
 

--- a/src/Microsoft.FeatureManagement.AspNetCore/Microsoft.FeatureManagement.AspNetCore.csproj
+++ b/src/Microsoft.FeatureManagement.AspNetCore/Microsoft.FeatureManagement.AspNetCore.csproj
@@ -3,10 +3,9 @@
 
   <!-- Official Version -->
   <PropertyGroup>
-    <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreviewVersion>-preview</PreviewVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Versioning.props" />

--- a/src/Microsoft.FeatureManagement.AspNetCore/Microsoft.FeatureManagement.AspNetCore.csproj
+++ b/src/Microsoft.FeatureManagement.AspNetCore/Microsoft.FeatureManagement.AspNetCore.csproj
@@ -3,9 +3,10 @@
 
   <!-- Official Version -->
   <PropertyGroup>
-    <MajorVersion>2</MajorVersion>
-    <MinorVersion>3</MinorVersion>
+    <MajorVersion>3</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
+    <PreviewVersion>-preview</PreviewVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Versioning.props" />

--- a/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement.Mvc.TagHelpers
@@ -55,8 +56,8 @@ namespace Microsoft.FeatureManagement.Mvc.TagHelpers
                 IEnumerable<string> names = Name.Split(',').Select(n => n.Trim());
 
                 enabled = Requirement == RequirementType.All ?
-                    await names.All(async n => await _featureManager.IsEnabledAsync(n).ConfigureAwait(false)) :
-                    await names.Any(async n => await _featureManager.IsEnabledAsync(n).ConfigureAwait(false));
+                    await names.All(async n => await _featureManager.IsEnabledAsync(n, CancellationToken.None).ConfigureAwait(false)) :
+                    await names.Any(async n => await _featureManager.IsEnabledAsync(n, CancellationToken.None).ConfigureAwait(false));
             }
 
             if (Negate)

--- a/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
@@ -56,8 +56,8 @@ namespace Microsoft.FeatureManagement.Mvc.TagHelpers
                 IEnumerable<string> names = Name.Split(',').Select(n => n.Trim());
 
                 enabled = Requirement == RequirementType.All ?
-                    await names.All(async n => await _featureManager.IsEnabledAsync(n, CancellationToken.None).ConfigureAwait(false)) :
-                    await names.Any(async n => await _featureManager.IsEnabledAsync(n, CancellationToken.None).ConfigureAwait(false));
+                    await names.All(async n => await _featureManager.IsEnabledAsync(n, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false) :
+                    await names.Any(async n => await _featureManager.IsEnabledAsync(n, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
             }
 
             if (Negate)

--- a/src/Microsoft.FeatureManagement.AspNetCore/UseForFeatureExtensions.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/UseForFeatureExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.FeatureManagement
                 {
                     IFeatureManager fm = context.RequestServices.GetRequiredService<IFeatureManagerSnapshot>();
 
-                    if (await fm.IsEnabledAsync(featureName).ConfigureAwait(false))
+                    if (await fm.IsEnabledAsync(featureName, context.RequestAborted).ConfigureAwait(false))
                     {
                         await branch(context).ConfigureAwait(false);
                     }

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,7 +41,7 @@ namespace Microsoft.FeatureManagement
             _changeSubscription = null;
         }
 
-        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName)
+        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken _)
         {
             if (featureName == null)
             {
@@ -63,7 +64,7 @@ namespace Microsoft.FeatureManagement
         // The async key word is necessary for creating IAsyncEnumerable.
         // The need to disable this warning occurs when implementaing async stream synchronously. 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync()
+        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync([EnumeratorCancellation] CancellationToken _)
 #pragma warning restore CS1998
         {
             if (Interlocked.Exchange(ref _stale, 0) != 0)

--- a/src/Microsoft.FeatureManagement/EmptySessionManager.cs
+++ b/src/Microsoft.FeatureManagement/EmptySessionManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -10,12 +11,12 @@ namespace Microsoft.FeatureManagement
     /// </summary>
     class EmptySessionManager : ISessionManager
     {
-        public Task SetAsync(string featureName, bool enabled)
+        public Task SetAsync(string featureName, bool enabled, CancellationToken _)
         {
             return Task.CompletedTask;
         }
 
-        public Task<bool?> GetAsync(string featureName)
+        public Task<bool?> GetAsync(string featureName, CancellationToken _)
         {
             return Task.FromResult((bool?)null);
         }

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement.Utils;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement.FeatureFilters
@@ -30,8 +31,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// Performs a percentage based evaluation to determine whether a feature is enabled.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, false otherwise.</returns>
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             PercentageFilterSettings settings = context.Parameters.Get<PercentageFilterSettings>() ?? new PercentageFilterSettings();
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement.FeatureFilters
@@ -30,8 +31,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// Evaluates whether a feature is enabled based on a configurable time window.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, false otherwise.</returns>
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             TimeWindowFilterSettings settings = context.Parameters.Get<TimeWindowFilterSettings>() ?? new TimeWindowFilterSettings();
 

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -3,6 +3,8 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -21,13 +23,13 @@ namespace Microsoft.FeatureManagement
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
         }
 
-        public async IAsyncEnumerable<string> GetFeatureNamesAsync()
+        public async IAsyncEnumerable<string> GetFeatureNamesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
         {
             if (_featureNames == null)
             {
                 var featureNames = new List<string>();
 
-                await foreach (string featureName in _featureManager.GetFeatureNamesAsync().ConfigureAwait(false))
+                await foreach (string featureName in _featureManager.GetFeatureNamesAsync(cancellationToken).ConfigureAwait(false))
                 {
                     featureNames.Add(featureName);
                 }
@@ -41,7 +43,7 @@ namespace Microsoft.FeatureManagement
             }
         }
 
-        public async Task<bool> IsEnabledAsync(string feature)
+        public async Task<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken)
         {
             //
             // First, check local cache
@@ -50,14 +52,14 @@ namespace Microsoft.FeatureManagement
                 return _flagCache[feature];
             }
 
-            bool enabled = await _featureManager.IsEnabledAsync(feature).ConfigureAwait(false);
+            bool enabled = await _featureManager.IsEnabledAsync(feature, cancellationToken).ConfigureAwait(false);
 
             _flagCache[feature] = enabled;
 
             return enabled;
         }
 
-        public async Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
+        public async Task<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken)
         {
             //
             // First, check local cache
@@ -66,7 +68,7 @@ namespace Microsoft.FeatureManagement
                 return _flagCache[feature];
             }
 
-            bool enabled = await _featureManager.IsEnabledAsync(feature, context).ConfigureAwait(false);
+            bool enabled = await _featureManager.IsEnabledAsync(feature, context, cancellationToken).ConfigureAwait(false);
 
             _flagCache[feature] = enabled;
 

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -18,7 +19,8 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
         /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
-        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext);
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureDefinitionProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -15,13 +16,15 @@ namespace Microsoft.FeatureManagement
         /// Retrieves the definition for a given feature.
         /// </summary>
         /// <param name="featureName">The name of the feature to retrieve the definition for.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The feature's definition.</returns>	
-        Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName);
+        Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves definitions for all features.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An enumerator which provides asynchronous iteration over feature definitions.</returns>
-        IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync();
+        IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -14,7 +15,8 @@ namespace Microsoft.FeatureManagement
         /// Evaluates the feature filter to see if the filter's criteria for being enabled has been satisfied.
         /// </summary>
         /// <param name="context">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
-        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context);
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -14,22 +15,25 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// Retrieves a list of feature names registered in the feature manager.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An enumerator which provides asynchronous iteration over the feature names registered in the feature manager.</returns>
-        IAsyncEnumerable<string> GetFeatureNamesAsync();
+        IAsyncEnumerable<string> GetFeatureNamesAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Checks whether a given feature is enabled.
         /// </summary>
         /// <param name="feature">The name of the feature to check.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        Task<bool> IsEnabledAsync(string feature);
+        Task<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken);
 
         /// <summary>
         /// Checks whether a given feature is enabled.
         /// </summary>
         /// <param name="feature">The name of the feature to check.</param>
         /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context);
+        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.FeatureManagement/ISessionManager.cs
+++ b/src/Microsoft.FeatureManagement/ISessionManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -15,13 +16,15 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="featureName">The name of the feature.</param>
         /// <param name="enabled">The state of the feature.</param>
-        Task SetAsync(string featureName, bool enabled);
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        Task SetAsync(string featureName, bool enabled, CancellationToken cancellationToken);
 
         /// <summary>
         /// Queries the session manager for the session's feature state, if any, for the given feature.
         /// </summary>
         /// <param name="featureName">The name of the feature.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The state of the feature if it is present in the session, otherwise null.</returns>
-        Task<bool?> GetAsync(string featureName);
+        Task<bool?> GetAsync(string featureName, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.FeatureManagement/Microsoft.FeatureManagement.csproj
+++ b/src/Microsoft.FeatureManagement/Microsoft.FeatureManagement.csproj
@@ -3,9 +3,10 @@
 
   <!-- Official Version -->
   <PropertyGroup>
-    <MajorVersion>2</MajorVersion>
-    <MinorVersion>3</MinorVersion>
+    <MajorVersion>3</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
+    <PreviewVersion>-preview</PreviewVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Versioning.props" />

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -8,6 +8,7 @@ using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement.FeatureFilters
@@ -40,9 +41,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
         /// <param name="targetingContext">The targeting context to use during targeting evaluation.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if either <paramref name="context"/> or <paramref name="targetingContext"/> is null.</exception>
         /// <returns>True if the feature is enabled, false otherwise.</returns>
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, ITargetingContext targetingContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, ITargetingContext targetingContext, CancellationToken cancellationToken)
         {
             if (context == null)
             {

--- a/src/Microsoft.FeatureManagement/Targeting/ITargetingContextAccessor.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ITargetingContextAccessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement.FeatureFilters
@@ -13,7 +14,8 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <summary>
         /// Retrieves the current targeting context.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The current targeting context.</returns>
-        ValueTask<TargetingContext> GetContextAsync();
+        ValueTask<TargetingContext> GetContextAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             //
             // Acquire targeting context via accessor
-            TargetingContext targetingContext = await _contextAccessor.GetContextAsync().ConfigureAwait(false);
+            TargetingContext targetingContext = await _contextAccessor.GetContextAsync(cancellationToken).ConfigureAwait(false);
 
             //
             // Ensure targeting can be performed

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement.FeatureFilters
@@ -36,9 +37,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// Performs a targeting evaluation using the current <see cref="TargetingContext"/> to determine if a feature should be enabled.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="context"/> is null.</exception>
         /// <returns>True if the feature is enabled, false otherwise.</returns>
-        public async Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public async Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             if (context == null)
             {
@@ -60,7 +62,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             //
             // Utilize contextual filter for targeting evaluation
-            return await _contextualFilter.EvaluateAsync(context, targetingContext).ConfigureAwait(false);
+            return await _contextualFilter.EvaluateAsync(context, targetingContext, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/tests/Tests.FeatureManagement/ContextualTestFilter.cs
+++ b/tests/Tests.FeatureManagement/ContextualTestFilter.cs
@@ -3,6 +3,7 @@
 //
 using Microsoft.FeatureManagement;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
@@ -11,7 +12,7 @@ namespace Tests.FeatureManagement
     {
         public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext, CancellationToken _)
         {
             return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
         }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -43,9 +44,9 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            Assert.True(await featureManager.IsEnabledAsync(OnFeature));
+            Assert.True(await featureManager.IsEnabledAsync(OnFeature, CancellationToken.None));
 
-            Assert.False(await featureManager.IsEnabledAsync(OffFeature));
+            Assert.False(await featureManager.IsEnabledAsync(OffFeature, CancellationToken.None));
 
             IEnumerable<IFeatureFilterMetadata> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
 
@@ -66,7 +67,7 @@ namespace Tests.FeatureManagement
                 return true;
             };
 
-            await featureManager.IsEnabledAsync(ConditionalFeature);
+            await featureManager.IsEnabledAsync(ConditionalFeature, CancellationToken.None);
 
             Assert.True(called);
         }
@@ -204,10 +205,10 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = provider.GetRequiredService<IFeatureManager>();
 
-            Assert.True(await featureManager.IsEnabledAsync(feature1));
-            Assert.False(await featureManager.IsEnabledAsync(feature2));
-            Assert.True(await featureManager.IsEnabledAsync(feature3));
-            Assert.False(await featureManager.IsEnabledAsync(feature4));
+            Assert.True(await featureManager.IsEnabledAsync(feature1, CancellationToken.None));
+            Assert.False(await featureManager.IsEnabledAsync(feature2, CancellationToken.None));
+            Assert.True(await featureManager.IsEnabledAsync(feature3, CancellationToken.None));
+            Assert.False(await featureManager.IsEnabledAsync(feature4, CancellationToken.None));
         }
 
         [Fact]
@@ -234,7 +235,7 @@ namespace Tests.FeatureManagement
 
             for (int i = 0; i < 10; i++)
             {
-                if (await featureManager.IsEnabledAsync(feature1))
+                if (await featureManager.IsEnabledAsync(feature1, CancellationToken.None))
                 {
                     enabledCount++;
                 }
@@ -272,21 +273,21 @@ namespace Tests.FeatureManagement
             Assert.True(await featureManager.IsEnabledAsync(targetingTestFeature, new TargetingContext
             {
                 UserId = "Jeff"
-            }));
+            }, CancellationToken.None));
 
             //
             // Not targeted by user id, but targeted by default rollout
             Assert.True(await featureManager.IsEnabledAsync(targetingTestFeature, new TargetingContext
             {
                 UserId = "Anne"
-            }));
+            }, CancellationToken.None));
 
             //
             // Not targeted by user id or default rollout
             Assert.False(await featureManager.IsEnabledAsync(targetingTestFeature, new TargetingContext
             {
                 UserId = "Patty"
-            }));
+            }, CancellationToken.None));
 
             //
             // Targeted by group rollout
@@ -294,7 +295,7 @@ namespace Tests.FeatureManagement
             {
                 UserId = "Patty",
                 Groups = new List<string>() { "Ring1" }
-            }));
+            }, CancellationToken.None));
 
             //
             // Not targeted by user id, default rollout or group rollout
@@ -302,7 +303,7 @@ namespace Tests.FeatureManagement
             {
                 UserId = "Isaac",
                 Groups = new List<string>() { "Ring1" }
-            }));
+            }, CancellationToken.None));
         }
 
         [Fact]
@@ -340,7 +341,7 @@ namespace Tests.FeatureManagement
                 UserId = "Jeff"
             };
 
-            Assert.True(await featureManager.IsEnabledAsync(beta));
+            Assert.True(await featureManager.IsEnabledAsync(beta, CancellationToken.None));
 
             //
             // Not targeted by user id or default rollout
@@ -349,7 +350,7 @@ namespace Tests.FeatureManagement
                 UserId = "Patty"
             };
 
-            Assert.False(await featureManager.IsEnabledAsync(beta));
+            Assert.False(await featureManager.IsEnabledAsync(beta, CancellationToken.None));
         }
 
         [Fact]
@@ -382,11 +383,11 @@ namespace Tests.FeatureManagement
 
             context.AccountId = "NotEnabledAccount";
 
-            Assert.False(await featureManager.IsEnabledAsync(ContextualFeature, context));
+            Assert.False(await featureManager.IsEnabledAsync(ContextualFeature, context, CancellationToken.None));
 
             context.AccountId = "abc";
 
-            Assert.True(await featureManager.IsEnabledAsync(ContextualFeature, context));
+            Assert.True(await featureManager.IsEnabledAsync(ContextualFeature, context, CancellationToken.None));
         }
 
         [Fact]
@@ -428,7 +429,7 @@ namespace Tests.FeatureManagement
 
                 bool hasItems = false;
 
-                await foreach (string feature in featureManager.GetFeatureNamesAsync())
+                await foreach (string feature in featureManager.GetFeatureNamesAsync(CancellationToken.None))
                 {
                     hasItems = true;
 
@@ -454,7 +455,8 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(async () => await featureManager.IsEnabledAsync(ConditionalFeature));
+            FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(
+                async () => await featureManager.IsEnabledAsync(ConditionalFeature, CancellationToken.None));
 
             Assert.Equal(FeatureManagementError.MissingFeatureFilter, e.Error);
         }
@@ -480,7 +482,7 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            var isEnabled = await featureManager.IsEnabledAsync(ConditionalFeature);
+            var isEnabled = await featureManager.IsEnabledAsync(ConditionalFeature, CancellationToken.None);
 
             Assert.False(isEnabled);
         }
@@ -533,7 +535,7 @@ namespace Tests.FeatureManagement
                 return true;
             };
 
-            await featureManager.IsEnabledAsync(ConditionalFeature);
+            await featureManager.IsEnabledAsync(ConditionalFeature, CancellationToken.None);
 
             Assert.True(called);
         }

--- a/tests/Tests.FeatureManagement/InMemoryFeatureDefinitionProvider.cs
+++ b/tests/Tests.FeatureManagement/InMemoryFeatureDefinitionProvider.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
@@ -16,7 +18,7 @@ namespace Tests.FeatureManagement
         }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync()
+        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync([EnumeratorCancellation] CancellationToken _)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             foreach (FeatureDefinition definition in _definitions)
@@ -25,7 +27,7 @@ namespace Tests.FeatureManagement
             }
         }
 
-        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName)
+        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken _)
         {
             return Task.FromResult(_definitions.FirstOrDefault(definitions => definitions.Name.Equals(featureName, StringComparison.OrdinalIgnoreCase)));
         }

--- a/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
+++ b/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Microsoft.FeatureManagement;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
@@ -10,12 +11,12 @@ namespace Tests.FeatureManagement
     // Cannot implement more than one IFeatureFilter interface
     class InvalidFeatureFilter : IContextualFeatureFilter<IAccountContext>, IContextualFeatureFilter<object>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext, CancellationToken _)
         {
             return Task.FromResult(false);
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext, CancellationToken _)
         {
             return Task.FromResult(false);
         }
@@ -25,12 +26,12 @@ namespace Tests.FeatureManagement
     // Cannot implement more than one IFeatureFilter interface
     class InvalidFeatureFilter2 : IFeatureFilter, IContextualFeatureFilter<object>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext, CancellationToken _)
         {
             return Task.FromResult(false);
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
         {
             return Task.FromResult(false);
         }

--- a/tests/Tests.FeatureManagement/OnDemandTargetingContextAccessor.cs
+++ b/tests/Tests.FeatureManagement/OnDemandTargetingContextAccessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Microsoft.FeatureManagement.FeatureFilters;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
@@ -10,7 +11,7 @@ namespace Tests.FeatureManagement
     {
         public TargetingContext Current { get; set; }
 
-        public ValueTask<TargetingContext> GetContextAsync()
+        public ValueTask<TargetingContext> GetContextAsync(CancellationToken _)
         {
             return new ValueTask<TargetingContext>(Current);
         }

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -3,6 +3,7 @@
 //
 using Microsoft.FeatureManagement;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
@@ -11,7 +12,7 @@ namespace Tests.FeatureManagement
     {
         public Func<FeatureFilterEvaluationContext, bool> Callback { get; set; }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
         {
             return Task.FromResult(Callback?.Invoke(context) ?? false);
         }


### PR DESCRIPTION
This PR adds a cancellation token parameter to async feature management interfaces. Adding this parameter is a breaking change and requires a major version bump. The project versions have been updated to 3.0.0-preview.