### PR TITLE
Added default value for cancellation token in interfaces.

### DIFF
--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -18,7 +18,7 @@ namespace Consoto.Banking.AccountService.FeatureManagement
     [FilterAlias("AccountId")]
     class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountContext, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountContext, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(accountContext?.AccountId))
             {

--- a/examples/FeatureFlagDemo/BrowserFilter.cs
+++ b/examples/FeatureFlagDemo/BrowserFilter.cs
@@ -24,7 +24,7 @@ namespace FeatureFlagDemo.FeatureManagement.FeatureFilters
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             BrowserFilterSettings settings = context.Parameters.Get<BrowserFilterSettings>() ?? new BrowserFilterSettings();
 

--- a/examples/FeatureFlagDemo/HttpContextTargetingContextAccessor.cs
+++ b/examples/FeatureFlagDemo/HttpContextTargetingContextAccessor.cs
@@ -24,7 +24,7 @@ namespace FeatureFlagDemo
             _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         }
 
-        public ValueTask<TargetingContext> GetContextAsync(CancellationToken _)
+        public ValueTask<TargetingContext> GetContextAsync(CancellationToken cancellationToken)
         {
             HttpContext httpContext = _httpContextAccessor.HttpContext;
 

--- a/examples/FeatureFlagDemo/SuperUserFilter.cs
+++ b/examples/FeatureFlagDemo/SuperUserFilter.cs
@@ -9,7 +9,7 @@ namespace FeatureFlagDemo.FeatureManagement.FeatureFilters
 {
     public class SuperUserFilter : IFeatureFilter
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(false);
         }

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.FeatureManagement
             _changeSubscription = null;
         }
 
-        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken _)
+        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken cancellationToken)
         {
             if (featureName == null)
             {
@@ -64,7 +64,7 @@ namespace Microsoft.FeatureManagement
         // The async key word is necessary for creating IAsyncEnumerable.
         // The need to disable this warning occurs when implementaing async stream synchronously. 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync([EnumeratorCancellation] CancellationToken _)
+        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
 #pragma warning restore CS1998
         {
             if (Interlocked.Exchange(ref _stale, 0) != 0)

--- a/src/Microsoft.FeatureManagement/EmptySessionManager.cs
+++ b/src/Microsoft.FeatureManagement/EmptySessionManager.cs
@@ -11,12 +11,12 @@ namespace Microsoft.FeatureManagement
     /// </summary>
     class EmptySessionManager : ISessionManager
     {
-        public Task SetAsync(string featureName, bool enabled, CancellationToken _)
+        public Task SetAsync(string featureName, bool enabled, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
 
-        public Task<bool?> GetAsync(string featureName, CancellationToken _)
+        public Task<bool?> GetAsync(string featureName, CancellationToken cancellationToken)
         {
             return Task.FromResult((bool?)null);
         }

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -21,6 +21,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
-        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext, CancellationToken cancellationToken);
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureDefinitionProvider.cs
@@ -18,13 +18,13 @@ namespace Microsoft.FeatureManagement
         /// <param name="featureName">The name of the feature to retrieve the definition for.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The feature's definition.</returns>	
-        Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken cancellationToken);
+        Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves definitions for all features.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An enumerator which provides asynchronous iteration over feature definitions.</returns>
-        IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync(CancellationToken cancellationToken);
+        IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilter.cs
@@ -17,6 +17,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="context">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
-        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken);
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/IFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An enumerator which provides asynchronous iteration over the feature names registered in the feature manager.</returns>
-        IAsyncEnumerable<string> GetFeatureNamesAsync(CancellationToken cancellationToken);
+        IAsyncEnumerable<string> GetFeatureNamesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Checks whether a given feature is enabled.
@@ -25,7 +25,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to check.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        Task<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken);
+        Task<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Checks whether a given feature is enabled.
@@ -34,6 +34,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken);
+        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/ISessionManager.cs
+++ b/src/Microsoft.FeatureManagement/ISessionManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="featureName">The name of the feature.</param>
         /// <param name="enabled">The state of the feature.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        Task SetAsync(string featureName, bool enabled, CancellationToken cancellationToken);
+        Task SetAsync(string featureName, bool enabled, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Queries the session manager for the session's feature state, if any, for the given feature.
@@ -25,6 +25,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="featureName">The name of the feature.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The state of the feature if it is present in the session, otherwise null.</returns>
-        Task<bool?> GetAsync(string featureName, CancellationToken cancellationToken);
+        Task<bool?> GetAsync(string featureName, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/ITargetingContextAccessor.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ITargetingContextAccessor.cs
@@ -16,6 +16,6 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The current targeting context.</returns>
-        ValueTask<TargetingContext> GetContextAsync(CancellationToken cancellationToken);
+        ValueTask<TargetingContext> GetContextAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/tests/Tests.FeatureManagement/ContextualTestFilter.cs
+++ b/tests/Tests.FeatureManagement/ContextualTestFilter.cs
@@ -12,7 +12,7 @@ namespace Tests.FeatureManagement
     {
         public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext, CancellationToken cancellationToken)
         {
             return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
         }

--- a/tests/Tests.FeatureManagement/InMemoryFeatureDefinitionProvider.cs
+++ b/tests/Tests.FeatureManagement/InMemoryFeatureDefinitionProvider.cs
@@ -18,7 +18,7 @@ namespace Tests.FeatureManagement
         }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync([EnumeratorCancellation] CancellationToken _)
+        public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             foreach (FeatureDefinition definition in _definitions)
@@ -27,7 +27,7 @@ namespace Tests.FeatureManagement
             }
         }
 
-        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken _)
+        public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName, CancellationToken cancellationToken)
         {
             return Task.FromResult(_definitions.FirstOrDefault(definitions => definitions.Name.Equals(featureName, StringComparison.OrdinalIgnoreCase)));
         }

--- a/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
+++ b/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
@@ -11,12 +11,12 @@ namespace Tests.FeatureManagement
     // Cannot implement more than one IFeatureFilter interface
     class InvalidFeatureFilter : IContextualFeatureFilter<IAccountContext>, IContextualFeatureFilter<object>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext, CancellationToken cancellationToken)
         {
             return Task.FromResult(false);
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext, CancellationToken cancellationToken)
         {
             return Task.FromResult(false);
         }
@@ -26,12 +26,12 @@ namespace Tests.FeatureManagement
     // Cannot implement more than one IFeatureFilter interface
     class InvalidFeatureFilter2 : IFeatureFilter, IContextualFeatureFilter<object>
     {
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext, CancellationToken cancellationToken)
         {
             return Task.FromResult(false);
         }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(false);
         }

--- a/tests/Tests.FeatureManagement/OnDemandTargetingContextAccessor.cs
+++ b/tests/Tests.FeatureManagement/OnDemandTargetingContextAccessor.cs
@@ -11,7 +11,7 @@ namespace Tests.FeatureManagement
     {
         public TargetingContext Current { get; set; }
 
-        public ValueTask<TargetingContext> GetContextAsync(CancellationToken _)
+        public ValueTask<TargetingContext> GetContextAsync(CancellationToken cancellationToken)
         {
             return new ValueTask<TargetingContext>(Current);
         }

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -12,7 +12,7 @@ namespace Tests.FeatureManagement
     {
         public Func<FeatureFilterEvaluationContext, bool> Callback { get; set; }
 
-        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken _)
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(Callback?.Invoke(context) ?? false);
         }


### PR DESCRIPTION
* Added default value for cancellation token in interfaces to keep existing usage possible.
* Updated internal, unused cancellation token parameter names to be more appropriate.

With the addition of default values, the usage in 2.3.0 `_featureManager.IsEnabledAsync("Beta")` is preserved.

Based off of feedback in: #131 