### PR TITLE
Add the capability to prevent features with feature filters from being evaluated.

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -167,10 +167,22 @@ namespace Microsoft.FeatureManagement
                 }
             }
 
+            bool evaluate = true;
+
+            val = configurationSection[nameof(FeatureDefinition.Evaluate)];
+
+            if (!string.IsNullOrEmpty(val) && !bool.TryParse(val, out evaluate))
+            {
+                throw new FeatureManagementException(
+                    FeatureManagementError.InvalidConfiguration,
+                    $"The feature '{configurationSection.Key}' has an invalid value for the '{nameof(FeatureDefinition.Evaluate)}' property.");
+            }
+
             return new FeatureDefinition()
             {
                 Name = configurationSection.Key,
-                EnabledFor = enabledFor
+                EnabledFor = enabledFor,
+                Evaluate = evaluate
             };
         }
 

--- a/src/Microsoft.FeatureManagement/FeatureDefinition.cs
+++ b/src/Microsoft.FeatureManagement/FeatureDefinition.cs
@@ -19,5 +19,11 @@ namespace Microsoft.FeatureManagement
         /// The feature filters that the feature can be enabled for.
         /// </summary>
         public IEnumerable<FeatureFilterConfiguration> EnabledFor { get; set; } = new List<FeatureFilterConfiguration>();
+
+        /// <summary>
+        /// Dictates whether the feature should be evaluated. If false, the feature will be considered disabled.
+        /// The default value is true.
+        /// </summary>
+        public bool Evaluate { get; set; } = true;
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -21,6 +21,11 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// A feature that was requested for evaluation was not found.
         /// </summary>
-        MissingFeature
+        MissingFeature,
+
+        /// <summary>
+        /// An invalid configuration was encountered when performing a feature management operation.
+        /// </summary>
+        InvalidConfiguration
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -74,7 +74,8 @@ namespace Microsoft.FeatureManagement
 
             FeatureDefinition featureDefinition = await _featureDefinitionProvider.GetFeatureDefinitionAsync(feature).ConfigureAwait(false);
 
-            if (featureDefinition != null)
+            if (featureDefinition != null
+                && featureDefinition.Evaluate)
             {
                 //
                 // Check if feature is always on
@@ -141,7 +142,7 @@ namespace Microsoft.FeatureManagement
                     }
                 }
             }
-            else
+            else if (featureDefinition == null)
             {
                 string errorMessage = $"The feature declaration for the feature '{feature}' was not found.";
 

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -26,6 +26,8 @@ namespace Tests.FeatureManagement
         private const string OffFeature = "OffFeature";
         private const string ConditionalFeature = "ConditionalFeature";
         private const string ContextualFeature = "ContextualFeature";
+        private const string AlwaysOnFeature = "AlwaysOnFeature";
+        private const string NonEvaluatedAlwaysOnFeature = "NonEvaluatedAlwaysOnFeature";
 
         [Fact]
         public async Task ReadsConfiguration()
@@ -613,6 +615,26 @@ namespace Tests.FeatureManagement
             {
                 Assert.Equal(result, t.Result);
             }
+        }
+
+        [Fact]
+        public async Task TogglesEvaluation()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var services = new ServiceCollection();
+
+            services
+                .AddSingleton(config)
+                .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync(AlwaysOnFeature));
+
+            Assert.False(await featureManager.IsEnabledAsync(NonEvaluatedAlwaysOnFeature));
         }
 
         private static void DisableEndpointRouting(MvcOptions options)

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -63,6 +63,21 @@
           }
         }
       ]
+    },
+    "AlwaysOnFeature": {
+      "EnabledFor": [
+        {
+          "Name": "AlwaysOn"
+        }
+      ]
+    },
+    "NonEvaluatedAlwaysOnFeature": {
+      "Evaluate": false,
+      "EnabledFor": [
+        {
+          "Name": "AlwaysOn"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR adds an enhancement to define features with feature filters that should not be evaluated.

There are times when developers configure feature filters for a feature but they do not want this feature to be on. This could be pre-emptive configuration of a feature to include feature filters that is later turned on. Or it could be that a feature is frequently turned off/on but there is a desire to preserve the configuration of filters.

Here is an example feature that has a feature filter registered, but should not be evaluated.
```
{
  "FeatureManagement": {
    "NonEvaluatedFeature": {
      "Evaluate": false,
      "EnabledFor": [
        {
          "Name": "MyFeatureFilter"
        }
      ]
    }
  }
}
```

For this feature, `await IsEnabledAsync("NonEvaluatedFeature` will return `false`.