### PR TITLE
Updated FilterAliasAttribute to use nameof(alias) when throwing an ArgumentNullException when the alias param is null or empty.

### DIFF
--- a/src/Microsoft.FeatureManagement/FilterAliasAttribute.cs
+++ b/src/Microsoft.FeatureManagement/FilterAliasAttribute.cs
@@ -18,7 +18,7 @@ namespace Microsoft.FeatureManagement
         {
             if (string.IsNullOrEmpty(alias))
             {
-                throw new ArgumentNullException(alias);
+                throw new ArgumentNullException(nameof(alias));
             }
 
             Alias = alias;


### PR DESCRIPTION
Updated FilterAliasAttribute to use nameof(alias) when throwing an ArgumentNullException when the alias param is null or empty. Fix for issue #145.