### PR TITLE
Add support for the ':' character in feature flags when using the default feature flag definition provider.

### DIFF
--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -63,6 +63,16 @@
           }
         }
       ]
+    },
+    "Feature:With:Colons": {
+      "EnabledFor": [
+        {
+          "Name": "Test",
+          "Parameters": {
+            "P1": "V1"
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR adds support for feature flags containing the ':' character.

Currently a feature with the name "Feature:With:Colons" cannot be found by the feature manager. With this change, the feature will now be found and evaluated as expected.