### PR TITLE
Fix PercentageFilter inequality bound

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             if (result)
             {
-                result = (RandomGenerator.NextDouble() * 100) <= settings.Value;
+                result = (RandomGenerator.NextDouble() * 100) < settings.Value;
             }
 
             return Task.FromResult(result);


### PR DESCRIPTION
NextDouble() ∈ [0, 1). We use a strict inequality, so a 0% rollout value sporadically returns true as 0⩽0.

The fix is to use a non-strict inequality, <. The upper bound still works: 0.999... < 1.

We noticed this internally because feature flags were occasionally tripping even with 0% rollout. This appears to be the root cause.