### PR TITLE
Updated missed "feature name" occurrences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,12 +261,12 @@ Some feature filters require parameters to decide whether a feature flag should 
 public class FeatureFilterEvaluationContext
 {
     /// <summary>
-    /// The name of the feature being evaluated.
+    /// The name of the feature flag being evaluated.
     /// </summary>
-    public string FeatureName { get; set; }
+    public string FeaturFlagName { get; set; }
 
     /// <summary>
-    /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled.
+    /// The settings provided for the feature filter to use when evaluating whether the feature flag should be enabled.
     /// </summary>
     public IConfiguration Parameters { get; set; }
 }
@@ -345,7 +345,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Providing a Context For Feature Evaluation
 
-In console applications there is no ambient context such as `HttpContext` that feature filters can acquire and utilize to check if a feature should be on or off. In this case, applications need to provide an object representing a context into the feature management system for use by feature filters. This is done by using `IFeatureManager.IsEnabledAsync<TContext>(string featureName, TContext appContext)`. The appContext object that is provided to the feature manager can be used by feature filters to evaluate the state of a feature flag.
+In console applications there is no ambient context such as `HttpContext` that feature filters can acquire and utilize to check if a feature should be on or off. In this case, applications need to provide an object representing a context into the feature management system for use by feature filters. This is done by using `IFeatureManager.IsEnabledAsync<TContext>(string featureFlagName, TContext appContext)`. The appContext object that is provided to the feature manager can be used by feature filters to evaluate the state of a feature flag.
 
 ``` C#
 MyAppContext context = new MyAppContext
@@ -806,7 +806,7 @@ To customize the loading of feature definitions, one must implement the `IFeatur
 ``` C#
 public interface IFeatureFlagDefinitionProvider
 {
-    Task<FeatureFlagDefinition> GetFeatureFlagDefinitionAsync(string featureName, CancellationToken cancellationToken = default);
+    Task<FeatureFlagDefinition> GetFeatureFlagDefinitionAsync(string featureflagName, CancellationToken cancellationToken = default);
 
     IAsyncEnumerable<FeatureFlagDefinition> GetAllFeatureFlagDefinitionsAsync(CancellationToken cancellationToken = default);
 }

--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ There are scenarios which require the state of a feature to remain consistent du
 
 Implementing a custom feature provider enable developers to pull feature flags from sources such as a database or a feature management service. The included feature provider that is used by default pulls feature flags from .NET Core's configuration system. This allows for features to be defined in an [appsettings.json](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#jcp) file or in configuration providers like [Azure App Configuration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/quickstart-feature-flag-aspnet-core?tabs=core2x). This behavior can be substituted to provide complete control of where feature definitions are read from.
 
-To customize the loading of feature definitions, one must implement the `IFeatureFlagDefinitionProvider` interface.
+To customize the loading of feature flag definitions, one must implement the `IFeatureFlagDefinitionProvider` interface.
 
 ``` C#
 public interface IFeatureFlagDefinitionProvider

--- a/src/Microsoft.FeatureManagement.AspNetCore/FeatureGateAttribute.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/FeatureGateAttribute.cs
@@ -11,90 +11,90 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement.Mvc
 {
     /// <summary>
-    /// An attribute that can be placed on MVC actions to require all or any of a set of features to be enabled. If none of the feature are enabled the registered <see cref="IDisabledFeaturesHandler"/> will be invoked.
+    /// An attribute that can be placed on MVC actions to require all or any of a set of feature flags to be enabled. If none of the feature flags are enabled, the registered <see cref="IDisabledFeaturesHandler"/> will be invoked.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
     public class FeatureGateAttribute : ActionFilterAttribute
     {
         /// <summary>
-        /// Creates an attribute that will gate actions unless all the provided feature(s) are enabled.
+        /// Creates an attribute that will gate actions unless all the provided feature flag(s) are enabled.
         /// </summary>
-        /// <param name="features">The names of the features that the attribute will represent.</param>
-        public FeatureGateAttribute(params string[] features)
-            : this(RequirementType.All, features)
+        /// <param name="featureFlags">The names of the feature flags that the attribute will represent.</param>
+        public FeatureGateAttribute(params string[] featureFlags)
+            : this(RequirementType.All, featureFlags)
         {
         }
 
         /// <summary>
-        /// Creates an attribute that can be used to gate actions. The gate can be configured to require all or any of the provided feature(s) to pass.
+        /// Creates an attribute that can be used to gate actions. The gate can be configured to require all or any of the provided feature flag(s) to pass.
         /// </summary>
-        /// <param name="requirementType">Specifies whether all or any of the provided features should be enabled in order to pass.</param>
-        /// <param name="features">The names of the features that the attribute will represent.</param>
-        public FeatureGateAttribute(RequirementType requirementType, params string[] features)
+        /// <param name="requirementType">Specifies whether all or any of the provided feature flags should be enabled in order to pass.</param>
+        /// <param name="featureFlags">The names of the feature flags that the attribute will represent.</param>
+        public FeatureGateAttribute(RequirementType requirementType, params string[] featureFlags)
         {
-            if (features == null || features.Length == 0)
+            if (featureFlags == null || featureFlags.Length == 0)
             {
-                throw new ArgumentNullException(nameof(features));
+                throw new ArgumentNullException(nameof(featureFlags));
             }
 
-            Features = features;
+            FeatureFlags = featureFlags;
 
             RequirementType = requirementType;
         }
 
         /// <summary>
-        /// Creates an attribute that will gate actions unless all the provided feature(s) are enabled.
+        /// Creates an attribute that will gate actions unless all the provided feature flag(s) are enabled.
         /// </summary>
-        /// <param name="features">A set of enums representing the features that the attribute will represent.</param>
+        /// <param name="features">A set of enums representing the feature flags that the attribute will represent.</param>
         public FeatureGateAttribute(params object[] features)
             : this(RequirementType.All, features)
         {
         }
 
         /// <summary>
-        /// Creates an attribute that can be used to gate actions. The gate can be configured to require all or any of the provided feature(s) to pass.
+        /// Creates an attribute that can be used to gate actions. The gate can be configured to require all or any of the provided feature flag(s) to pass.
         /// </summary>
-        /// <param name="requirementType">Specifies whether all or any of the provided features should be enabled in order to pass.</param>
-        /// <param name="features">A set of enums representing the features that the attribute will represent.</param>
-        public FeatureGateAttribute(RequirementType requirementType, params object[] features)
+        /// <param name="requirementType">Specifies whether all or any of the provided feature flags should be enabled in order to pass.</param>
+        /// <param name="featureFlags">A set of enums representing the feature flags that the attribute will represent.</param>
+        public FeatureGateAttribute(RequirementType requirementType, params object[] featureFlags)
         {
-            if (features == null || features.Length == 0)
+            if (featureFlags == null || featureFlags.Length == 0)
             {
-                throw new ArgumentNullException(nameof(features));
+                throw new ArgumentNullException(nameof(featureFlags));
             }
 
             var fs = new List<string>();
 
-            foreach (object feature in features)
+            foreach (object feature in featureFlags)
             {
                 var type = feature.GetType();
 
                 if (!type.IsEnum)
                 {
                     // invalid
-                    throw new ArgumentException("The provided features must be enums.", nameof(features));
+                    throw new ArgumentException("The provided feature flags must be enums.", nameof(featureFlags));
                 }
 
                 fs.Add(Enum.GetName(feature.GetType(), feature));
             }
 
-            Features = fs;
+            FeatureFlags = fs;
 
             RequirementType = requirementType;
         }
 
         /// <summary>
-        /// The name of the features that the feature attribute will activate for.
+        /// The name of the feature flags that the feature gate attribute will activate for.
         /// </summary>
-        public IEnumerable<string> Features { get; }
+        public IEnumerable<string> FeatureFlags { get; }
 
         /// <summary>
-        /// Controls whether any or all features in <see cref="Features"/> should be enabled to pass.
+        /// Controls whether any or all feature flags in <see cref="FeatureFlags"/> should be enabled to pass.
         /// </summary>
         public RequirementType RequirementType { get; }
 
         /// <summary>
-        /// Performs controller action pre-procesing to ensure that at least one of the specified features are enabled.
+        /// Performs controller action pre-procesing to ensure that at least one of the specified feature flags are enabled.
         /// </summary>
         /// <param name="context">The context of the MVC action.</param>
         /// <param name="next">The action delegate.</param>
@@ -104,10 +104,10 @@ namespace Microsoft.FeatureManagement.Mvc
             IFeatureManagerSnapshot fm = context.HttpContext.RequestServices.GetRequiredService<IFeatureManagerSnapshot>();
 
             //
-            // Enabled state is determined by either 'any' or 'all' features being enabled.
+            // Enabled state is determined by either 'any' or 'all' feature flags being enabled.
             bool enabled = RequirementType == RequirementType.All ?
-                             await Features.All(async feature => await fm.IsEnabledAsync(feature, context.HttpContext.RequestAborted).ConfigureAwait(false)).ConfigureAwait(false) :
-                             await Features.Any(async feature => await fm.IsEnabledAsync(feature, context.HttpContext.RequestAborted).ConfigureAwait(false)).ConfigureAwait(false);
+                             await FeatureFlags.All(async feature => await fm.IsEnabledAsync(feature, context.HttpContext.RequestAborted).ConfigureAwait(false)).ConfigureAwait(false) :
+                             await FeatureFlags.Any(async feature => await fm.IsEnabledAsync(feature, context.HttpContext.RequestAborted).ConfigureAwait(false)).ConfigureAwait(false);
 
             if (enabled)
             {
@@ -117,7 +117,7 @@ namespace Microsoft.FeatureManagement.Mvc
             {
                 IDisabledFeaturesHandler disabledFeaturesHandler = context.HttpContext.RequestServices.GetService<IDisabledFeaturesHandler>() ?? new NotFoundDisabledFeaturesHandler();
 
-                await disabledFeaturesHandler.HandleDisabledFeatures(Features, context).ConfigureAwait(false);
+                await disabledFeaturesHandler.HandleDisabledFeatures(FeatureFlags, context).ConfigureAwait(false);
             }
         }
     }

--- a/src/Microsoft.FeatureManagement.AspNetCore/FeatureGatedAsyncActionFilter.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/FeatureGatedAsyncActionFilter.cs
@@ -9,28 +9,28 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// A place holder MVC filter that is used to dynamically activate a filter based on whether a feature is enabled.
+    /// A place holder MVC filter that is used to dynamically activate a filter based on whether a feature flag is enabled.
     /// </summary>
     /// <typeparam name="T">The filter that will be used instead of this placeholder.</typeparam>
     class FeatureGatedAsyncActionFilter<T> : IAsyncActionFilter where T : IAsyncActionFilter
     {
-        public FeatureGatedAsyncActionFilter(string featureName)
+        public FeatureGatedAsyncActionFilter(string featureFlagName)
         {
-            if (string.IsNullOrEmpty(featureName))
+            if (string.IsNullOrEmpty(featureFlagName))
             {
-                throw new ArgumentNullException(nameof(featureName));
+                throw new ArgumentNullException(nameof(featureFlagName));
             }
 
-            FeatureName = featureName;
+            FeatureFlagName = featureFlagName;
         }
 
-        public string FeatureName { get; }
+        public string FeatureFlagName { get; }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
             IFeatureManager featureManager = context.HttpContext.RequestServices.GetRequiredService<IFeatureManagerSnapshot>();
 
-            if (await featureManager.IsEnabledAsync(FeatureName, context.HttpContext.RequestAborted).ConfigureAwait(false))
+            if (await featureManager.IsEnabledAsync(FeatureFlagName, context.HttpContext.RequestAborted).ConfigureAwait(false))
             {
                 IServiceProvider serviceProvider = context.HttpContext.RequestServices.GetRequiredService<IServiceProvider>();
 

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -6,17 +6,17 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// A context used by <see cref="IFeatureFilter"/> to gain insight into what feature is being evaluated and the parameters needed to check whether the feature should be enabled.
+    /// A context used by <see cref="IFeatureFilter"/> to gain insight into what feature flag is being evaluated and the parameters needed to check whether the feature flag should be enabled.
     /// </summary>
     public class FeatureFilterEvaluationContext
     {
         /// <summary>
-        /// The name of the feature being evaluated.
+        /// The name of the feature flag being evaluated.
         /// </summary>
-        public string FeatureName { get; set; }
+        public string FeatureFlagName { get; set; }
 
         /// <summary>
-        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled.
+        /// The settings provided for the feature filter to use when evaluating whether the feature flag should be enabled.
         /// </summary>
         public IConfiguration Parameters { get; set; }
     }

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -28,11 +28,11 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         /// <summary>
-        /// Performs a percentage based evaluation to determine whether a feature is enabled.
+        /// Performs a percentage based evaluation to determine whether a feature flag is enabled.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>True if the feature is enabled, false otherwise.</returns>
+        /// <returns>True if the feature flag is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             PercentageFilterSettings settings = context.Parameters.Get<PercentageFilterSettings>() ?? new PercentageFilterSettings();
@@ -41,7 +41,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             if (settings.Value < 0)
             {
-                _logger.LogWarning($"The '{Alias}' feature filter does not have a valid '{nameof(settings.Value)}' value for feature '{context.FeatureName}'");
+                _logger.LogWarning($"The '{Alias}' feature filter does not have a valid '{nameof(settings.Value)}' value for the feature flag '{context.FeatureFlagName}'");
 
                 result = false;
             }

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilterSettings.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilterSettings.cs
@@ -9,7 +9,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     public class PercentageFilterSettings
     {
         /// <summary>
-        /// A value between 0 and 100 specifying the chance that a feature configured to use the <see cref="PercentageFilter"/> should be enabled.
+        /// A value between 0 and 100 specifying the chance that a feature flag configured to use the <see cref="PercentageFilter"/> should be enabled.
         /// </summary>
         public int Value { get; set; } = -1;
     }

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement.FeatureFilters
 {
     /// <summary>
-    /// A feature filter that can be used to activate a feature based on a time window.
+    /// A feature filter that can be used to activate a feature flag based on a time window.
     /// </summary>
     [FilterAlias(Alias)]
     public class TimeWindowFilter : IFeatureFilter
@@ -28,11 +28,11 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         /// <summary>
-        /// Evaluates whether a feature is enabled based on a configurable time window.
+        /// Evaluates whether a feature flag is enabled based on a configurable time window.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>True if the feature is enabled, false otherwise.</returns>
+        /// <returns>True if the feature flag is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             TimeWindowFilterSettings settings = context.Parameters.Get<TimeWindowFilterSettings>() ?? new TimeWindowFilterSettings();
@@ -41,7 +41,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             if (!settings.Start.HasValue && !settings.End.HasValue)
             {
-                _logger.LogWarning($"The '{Alias}' feature filter is not valid for feature '{context.FeatureName}'. It must have have specify either '{nameof(settings.Start)}', '{nameof(settings.End)}', or both.");
+                _logger.LogWarning($"The '{Alias}' feature filter is not valid for the feature flag '{context.FeatureFlagName}'. It must have have specify either '{nameof(settings.Start)}', '{nameof(settings.End)}', or both.");
 
                 return Task.FromResult(false);
             }

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilterSettings.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilterSettings.cs
@@ -11,13 +11,13 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     public class TimeWindowFilterSettings
     {
         /// <summary>
-        /// An optional start time used to determine when a feature configured to use the <see cref="TimeWindowFilter"/> feature filter should be enabled.
+        /// An optional start time used to determine when a feature flag configured to use the <see cref="TimeWindowFilter"/> feature filter should be enabled.
         /// If no start time is specified the time window is considered to have already started.
         /// </summary>
         public DateTimeOffset? Start { get; set; } // E.g. "Wed, 01 May 2019 22:59:30 GMT"
 
         /// <summary>
-        /// An optional end time used to determine when a feature configured to use the <see cref="TimeWindowFilter"/> feature filter should be enabled.
+        /// An optional end time used to determine when a feature flag configured to use the <see cref="TimeWindowFilter"/> feature filter should be enabled.
         /// If no end time is specified the time window is considered to never end.
         /// </summary>
         public DateTimeOffset? End { get; set; } // E.g. "Wed, 01 May 2019 23:00:00 GMT"

--- a/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.FeatureManagement
     {
         /// <summary>
         /// Controls the behavior of feature evaluation when dependent feature filters are missing.
-        /// If missing feature filters are not ignored an exception will be thrown when attempting to evaluate a feature that depends on a missing feature filter.
+        /// If missing feature filters are not ignored an exception will be thrown when attempting to evaluate a feature flag that depends on a missing feature filter.
         /// </summary>
         public bool IgnoreMissingFeatureFilters { get; set; }
     }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -121,7 +121,7 @@ namespace Microsoft.FeatureManagement
 
                         var context = new FeatureFilterEvaluationContext()
                         {
-                            FeatureName = featureDefinition.Name,
+                            FeatureFlagName = featureDefinition.Name,
                             Parameters = featureFilterConfiguration.Parameters
                         };
 

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -7,8 +7,8 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content.
-    /// Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
+    /// A filter that can be used to determine whether some criteria is met to enable a feature flag. A feature filter is free to use any criteria available, such as process state or request content.
+    /// Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature flag will be considered enabled.
     /// A contextual feature filter can take advantage of contextual data passed in from callers of the feature management system.
     /// A contextual feature filter will only be executed if a context that is assignable from TContext is available.
     /// </summary>
@@ -17,8 +17,8 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// Evaluates the feature filter to see if the filter's criteria for being enabled has been satisfied.
         /// </summary>
-        /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
-        /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
+        /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature flag being evaluated.</param>
+        /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature flag's state.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
         Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext, CancellationToken cancellationToken = default);

--- a/src/Microsoft.FeatureManagement/IFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilter.cs
@@ -7,14 +7,14 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content. Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
+    /// A filter that can be used to determine whether some criteria is met to enable a feature flag. A feature filter is free to use any criteria available, such as process state or request content. Feature filters can be registered for a given feature flag and if any feature filter evaluates to true, that feature flag will be considered enabled.
     /// </summary>
     public interface IFeatureFilter : IFeatureFilterMetadata
     {
         /// <summary>
         /// Evaluates the feature filter to see if the filter's criteria for being enabled has been satisfied.
         /// </summary>
-        /// <param name="context">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
+        /// <param name="context">A feature filter evaluation context that contains information that may be needed to evaluate the filter. This context includes configuration, if any, for this filter for the feature flag being evaluated.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
         Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken = default);

--- a/src/Microsoft.FeatureManagement/IFeatureFilterMetadata.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilterMetadata.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// Marker interface for feature filters used to evaluate the state of a feature
+    /// Marker interface for feature filters used to evaluate the state of a feature flag.
     /// </summary>
     public interface IFeatureFilterMetadata
     {

--- a/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.FeatureManagement
         IServiceCollection Services { get; }
 
         /// <summary>
-        /// Adds a given feature filter to the list of feature filters that will be available to enable features during runtime.
+        /// Adds a given feature filter to the list of feature filters that will be available to enable feature flags during runtime.
         /// Possible feature filter metadata types include <see cref="IFeatureFilter"/> and <see cref="IContextualFeatureFilter{TContext}"/>
         /// Only one feature filter interface can be implemented by a single type.
         /// </summary>
@@ -25,7 +25,7 @@ namespace Microsoft.FeatureManagement
         IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilterMetadata;
 
         /// <summary>
-        /// Adds an <see cref="ISessionManager"/> to be used for storing feature state in a session.
+        /// Adds an <see cref="ISessionManager"/> to be used for storing feature flag state in a session.
         /// </summary>
         /// <typeparam name="T">An implementation of <see cref="ISessionManager"/></typeparam>
         /// <returns>The feature management builder.</returns>

--- a/src/Microsoft.FeatureManagement/IFeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManagerSnapshot.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// Provides a snapshot of feature state to ensure consistency across a given request.
+    /// Provides a snapshot of feature flag state to ensure consistency across a given request.
     /// </summary>
     public interface IFeatureManagerSnapshot : IFeatureManager
     {

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
@@ -31,7 +31,7 @@ namespace Microsoft.FeatureManagement.Assigners
         }
 
         /// <summary>
-        /// Assigns one of the variants configured for a feature based off the provided targeting context.
+        /// Assigns one of the variants configured for a dynamic feature based off the provided targeting context.
         /// </summary>
         /// <param name="variantAssignmentContext">Contextual information available for use during the assignment process.</param>
         /// <param name="targetingContext">The targeting context used to determine which variant should be assigned.</param>

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement.FeatureFilters
 {
     /// <summary>
-    /// A feature filter that can be used to activate features for targeted audiences.
+    /// A feature filter that can be used to activate feature flags for targeted audiences.
     /// </summary>
     [FilterAlias(Alias)]
     public class ContextualTargetingFilter : IContextualFeatureFilter<ITargetingContext>
@@ -29,13 +29,13 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         /// <summary>
-        /// Performs a targeting evaluation using the provided <see cref="TargetingContext"/> to determine if a feature should be enabled.
+        /// Performs a targeting evaluation using the provided <see cref="TargetingContext"/> to determine if a feature flag should be enabled.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
         /// <param name="targetingContext">The targeting context to use during targeting evaluation.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if either <paramref name="context"/> or <paramref name="targetingContext"/> is null.</exception>
-        /// <returns>True if the feature is enabled, false otherwise.</returns>
+        /// <returns>True if the feature flag is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, ITargetingContext targetingContext, CancellationToken cancellationToken)
         {
             if (context == null)
@@ -50,7 +50,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             TargetingFilterSettings settings = context.Parameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
 
-            return Task.FromResult(TargetingEvaluator.IsTargeted(settings, targetingContext, _options.IgnoreCase, context.FeatureName));
+            return Task.FromResult(TargetingEvaluator.IsTargeted(settings, targetingContext, _options.IgnoreCase, context.FeatureFlagName));
         }
     }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFeatureVariantAssigner.cs
@@ -22,7 +22,7 @@ namespace Microsoft.FeatureManagement.Assigners
         private readonly ILogger _logger;
 
         /// <summary>
-        /// Creates a feature variant assigner that uses targeting to assign which of a feature's registered variants should be used.
+        /// Creates a feature variant assigner that uses targeting to assign which of a dynamic feature's registered variants should be used.
         /// </summary>
         /// <param name="options">The options controlling how targeting is performed.</param>
         /// <param name="contextAccessor">An accessor for the targeting context required to perform a targeting evaluation.</param>
@@ -37,7 +37,7 @@ namespace Microsoft.FeatureManagement.Assigners
         }
 
         /// <summary>
-        /// Assigns one of the variants configured for a feature based off the provided targeting context.
+        /// Assigns one of the variants configured for a dynamic feature based off the provided targeting context.
         /// </summary>
         /// <param name="variantAssignmentContext">Contextual information available for use during the assignment process.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement.FeatureFilters
 {
     /// <summary>
-    /// A feature filter that can be used to activate features for targeted audiences.
+    /// A feature filter that can be used to activate feature flags for targeted audiences.
     /// </summary>
     [FilterAlias(Alias)]
     public class TargetingFilter : IFeatureFilter
@@ -34,12 +34,12 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         /// <summary>
-        /// Performs a targeting evaluation using the current <see cref="TargetingContext"/> to determine if a feature should be enabled.
+        /// Performs a targeting evaluation using the current <see cref="TargetingContext"/> to determine if a feature flag should be enabled.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="context"/> is null.</exception>
-        /// <returns>True if the feature is enabled, false otherwise.</returns>
+        /// <returns>True if the feature flag is enabled, false otherwise.</returns>
         public async Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
             if (context == null)

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFilterSettings.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFilterSettings.cs
@@ -9,7 +9,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     public class TargetingFilterSettings
     {
         /// <summary>
-        /// The audience that a feature configured to use the <see cref="TargetingFilter"/> should be enabled for.
+        /// The audience that a feature flag configured to use the <see cref="TargetingFilter"/> should be enabled for.
         /// </summary>
         public Audience Audience { get; set; }
     }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -66,7 +66,7 @@ namespace Tests.FeatureManagement
 
                 Assert.Equal("V1", evaluationContext.Parameters["P1"]);
 
-                Assert.Equal(ConditionalFeature, evaluationContext.FeatureName);
+                Assert.Equal(ConditionalFeature, evaluationContext.FeatureFlagName);
 
                 return true;
             };
@@ -153,7 +153,7 @@ namespace Tests.FeatureManagement
 
                 Assert.Equal("V1", evaluationContext.Parameters["P1"]);
 
-                Assert.Equal(ConditionalFeature, evaluationContext.FeatureName);
+                Assert.Equal(ConditionalFeature, evaluationContext.FeatureFlagName);
 
                 return true;
             };
@@ -291,7 +291,7 @@ namespace Tests.FeatureManagement
 
             //
             // Enable 1/2 features
-            testFeatureFilter.Callback = ctx => ctx.FeatureName == Features.ConditionalFeature;
+            testFeatureFilter.Callback = ctx => ctx.FeatureFlagName == Features.ConditionalFeature;
 
             gateAllResponse = await testServer.CreateClient().GetAsync("gateAll");
             gateAnyResponse = await testServer.CreateClient().GetAsync("gateAny");
@@ -950,7 +950,7 @@ namespace Tests.FeatureManagement
 
                 Assert.Equal("V1", evaluationContext.Parameters["P1"]);
 
-                Assert.Equal(ConditionalFeature, evaluationContext.FeatureName);
+                Assert.Equal(ConditionalFeature, evaluationContext.FeatureFlagName);
 
                 return true;
             };


### PR DESCRIPTION
With the introduction of dynamic features, APIs were updated to distinguish between feature flags and dynamic features. As mentioned in #160 a few places were missed. This PR is a second pass to update spots that use "feature" where "feature flag" would be more appropriate.