### PR TITLE
Allow for both IFeatureFilter and IContextualFeatureFilter with same alias

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
@@ -21,5 +21,11 @@ namespace Microsoft.FeatureManagement
         /// The default value is true.
         /// </summary>
         public bool IgnoreMissingFeatures { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to allow for the same alias name to be used for a <see cref="IFeatureFilter" /> and a
+        /// <see cref="IContextualFeatureFilter{TContext}" />. Default is false.
+        /// </summary>
+        public bool AllowDuplicateContextualAlias { get; set; }
     }
 }


### PR DESCRIPTION
This PR introduces an opt-in mechanic to allow for having `IFeatureFilter` and `IContextualFeatureFilter` with the same alias. Specifically, you can have:

0 or 1 `IFeatureFilter`
0 or N `IContextualFeatureFilter<T>`, so long as there is at most 1 applicable filter for `T`. So, you can have multiple contextual filters with the same alias, so long as they all handle discrete app contexts.

By default, this functionality is **disabled** and can be enabled via `FeatureManagementOptions.AllowDuplicateContextualAlias`.

TODO:
- [ ] Add unit tests

Closes #98 