### PR TITLE
Implement a default/global feature definition

### DIFF
--- a/src/Microsoft.FeatureManagement/Comparers/CompareByNameFeatureFilterConfigurationComparer.cs
+++ b/src/Microsoft.FeatureManagement/Comparers/CompareByNameFeatureFilterConfigurationComparer.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.FeatureManagement.Comparers
+{
+    /// <summary>
+    /// Compares two FeatureFilterConfiguration using only the name
+    /// </summary>
+    public class CompareByNameFeatureFilterConfigurationComparer : IEqualityComparer<FeatureFilterConfiguration>
+    {
+        public bool Equals(FeatureFilterConfiguration x, FeatureFilterConfiguration y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            if (x.GetType() != y.GetType()) return false;
+            return x.Name == y.Name;
+        }
+
+        public int GetHashCode(FeatureFilterConfiguration obj)
+        {
+            return (obj.Name != null ? obj.Name.GetHashCode() : 0);
+        }
+    }
+}

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -415,7 +415,8 @@ namespace Tests.FeatureManagement
 
             serviceCollection.AddSingleton(config)
                 .AddFeatureManagement()
-                .AddFeatureFilter<ContextualTestFilter>();
+                .AddFeatureFilter<ContextualTestFilter>()
+                .AddFeatureFilter<TestFilter>();
 
             ServiceProvider provider = serviceCollection.BuildServiceProvider();
 
@@ -667,6 +668,27 @@ namespace Tests.FeatureManagement
             {
                 Assert.Equal(result, t.Result);
             }
+        }
+
+        [Fact]
+        public async Task DefaultFeatureDefinition()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings-with-default.json").Build();
+
+            var services = new ServiceCollection();
+
+            services
+                .AddSingleton(config)
+                .AddFeatureManagement()
+                .AddFeatureFilter<TestFilter>();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            var featureDefinitionProvider = serviceProvider.GetRequiredService<IFeatureDefinitionProvider>();
+
+            var definition = await featureDefinitionProvider.GetFeatureDefinitionAsync(nameof(Features.OffTestFeature));
+            
+            Assert.Collection(definition.EnabledFor, configuration => configuration.Name.Equals("Test"));
         }
 
         private static void DisableEndpointRouting(MvcOptions options)

--- a/tests/Tests.FeatureManagement/appsettings-with-default.json
+++ b/tests/Tests.FeatureManagement/appsettings-with-default.json
@@ -1,0 +1,75 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+
+  "FeatureManagement": {
+    "Default": {
+      "EnabledFor": [
+        {
+          "name": "Test"
+        }
+      ]
+    },
+    "OnTestFeature": true,
+    "OffTestFeature": false,
+    "TargetingTestFeature": {
+      "EnabledFor": [
+        {
+          "Name": "Targeting",
+          "Parameters": {
+            "Audience": {
+              "Users": [
+                "Jeff",
+                "Alicia"
+              ],
+              "Groups": [
+                {
+                  "Name": "Ring0",
+                  "RolloutPercentage": 100
+                },
+                {
+                  "Name": "Ring1",
+                  "RolloutPercentage": 50
+                }
+              ],
+              "DefaultRolloutPercentage": 20
+            }
+          }
+        }
+      ]
+    },
+    "ConditionalFeature": {
+      "EnabledFor": [
+        {
+          "Name": "Test",
+          "Parameters": {
+            "P1": "V1"
+          }
+        }
+      ]
+    },
+    "ConditionalFeature2": {
+      "EnabledFor": [
+        {
+          "Name": "Test"
+        }
+      ]
+    },
+    "ContextualFeature": {
+      "EnabledFor": [
+        {
+          "Name": "ContextualTest",
+          "Parameters": {
+            "AllowedAccounts": [
+              "abc"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces an option to have global/default feature definition.

The benefit is allow use definitions that would apply for all features without need to set it individually.

For more information check feature request #89 