### PR TITLE
Fixed targeting assignment precedence.

### DIFF
--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
@@ -67,24 +67,24 @@ namespace Microsoft.FeatureManagement.Assigners
 
             FeatureVariant variant = null;
 
-            double cumulativePercentage = 0;
+            var lookup = new Dictionary<FeatureVariant, TargetingFilterSettings>();
 
-            var cumulativeGroups = new Dictionary<string, double>(
-                _options.IgnoreCase ? StringComparer.OrdinalIgnoreCase :
-                                      StringComparer.Ordinal);
-
+            //
+            // Check users
             foreach (FeatureVariant v in featureDefinition.Variants)
             {
                 TargetingFilterSettings targetingSettings = v.AssignmentParameters.Get<TargetingFilterSettings>();
 
-                if (targetingSettings == null)
+                //
+                // Put in lookup table to avoid repeatedly creating targeting settings
+                lookup[v] = targetingSettings;
+
+                if (targetingSettings == null &&
+                    v.Default)
                 {
-                    if (v.Default)
-                    {
-                        //
-                        // Valid to omit audience for default variant
-                        continue;
-                    }
+                    //
+                    // Valid to omit audience for default variant
+                    continue;
                 }
 
                 if (!TargetingEvaluator.TryValidateSettings(targetingSettings, out string paramName, out string reason))
@@ -92,44 +92,103 @@ namespace Microsoft.FeatureManagement.Assigners
                     throw new ArgumentException(reason, paramName);
                 }
 
-                AccumulateAudience(targetingSettings.Audience, cumulativeGroups, ref cumulativePercentage);
-
-                if (TargetingEvaluator.IsTargeted(targetingSettings, targetingContext, _options.IgnoreCase, featureDefinition.Name))
+                //
+                // Check if the user is being targeted directly
+                if (targetingSettings.Audience.Users != null &&
+                    TargetingEvaluator.IsTargeted(
+                        targetingContext,
+                        targetingSettings.Audience.Users,
+                        _options.IgnoreCase))
                 {
-                    variant = v;
-
-                    break;
+                    return new ValueTask<FeatureVariant>(v);
                 }
             }
 
-            return new ValueTask<FeatureVariant>(variant);
+            var cumulativeGroups = new Dictionary<string, double>(
+                _options.IgnoreCase ? StringComparer.OrdinalIgnoreCase :
+                                      StringComparer.Ordinal);
+
+            //
+            // Check Groups
+            foreach (FeatureVariant v in featureDefinition.Variants)
+            {
+                TargetingFilterSettings targetingSettings = lookup[v];
+
+                if (targetingSettings == null ||
+                    targetingSettings.Audience.Groups == null)
+                {
+                    continue;
+                }
+
+                AccumulateGroups(targetingSettings.Audience, cumulativeGroups);
+
+                if (TargetingEvaluator.IsTargeted(
+                    targetingContext,
+                    targetingSettings.Audience.Groups,
+                    _options.IgnoreCase,
+                    featureDefinition.Name))
+                {
+                    return new ValueTask<FeatureVariant>(v);
+                }
+            }
+
+            double cumulativePercentage = 0;
+
+            //
+            // Check default rollout percentage
+            foreach (FeatureVariant v in featureDefinition.Variants)
+            {
+                TargetingFilterSettings targetingSettings = lookup[v];
+
+                if (targetingSettings == null)
+                {
+                    continue;
+                }
+
+                AccumulateDefaultRollout(targetingSettings.Audience, ref cumulativePercentage);
+
+                if (TargetingEvaluator.IsTargeted(
+                    targetingContext,
+                    targetingSettings.Audience.DefaultRolloutPercentage,
+                    _options.IgnoreCase,
+                    featureDefinition.Name))
+                {
+                    return new ValueTask<FeatureVariant>(v);
+                }
+            }
+
+            return new ValueTask<FeatureVariant>((FeatureVariant)null);
         }
 
         /// <summary>
-        /// Accumulates percentages for groups and the default rollout for an audience.
+        /// Accumulates percentages for groups of an audience.
+        /// </summary>
+        /// <param name="audience">The audience that will have its percentages updated based on currently accumulated percentages</param>
+        /// <param name="cumulativeGroups">The current cumulative rollout percentage for each group</param>
+        private static void AccumulateGroups(Audience audience, Dictionary<string, double> cumulativeGroups)
+        {
+            foreach (GroupRollout gr in audience.Groups)
+            {
+                double percentage = gr.RolloutPercentage;
+
+                if (cumulativeGroups.TryGetValue(gr.Name, out double p))
+                {
+                    percentage += p;
+                }
+
+                cumulativeGroups[gr.Name] = percentage;
+
+                gr.RolloutPercentage = percentage;
+            }
+        }
+
+        /// <summary>
+        /// Accumulates percentages for the  default rollout of an audience.
         /// </summary>
         /// <param name="audience">The audience that will have its percentages updated based on currently accumulated percentages</param>
         /// <param name="cumulativeDefaultPercentage">The current cumulative default rollout percentage</param>
-        /// <param name="cumulativeGroups">The current cumulative rollout percentage for each group</param>
-        private static void AccumulateAudience(Audience audience, Dictionary<string, double> cumulativeGroups, ref double cumulativeDefaultPercentage)
+        private static void AccumulateDefaultRollout(Audience audience, ref double cumulativeDefaultPercentage)
         {
-            if (audience.Groups != null)
-            {
-                foreach (GroupRollout gr in audience.Groups)
-                {
-                    double percentage = gr.RolloutPercentage;
-
-                    if (cumulativeGroups.TryGetValue(gr.Name, out double p))
-                    {
-                        percentage += p;
-                    }
-
-                    cumulativeGroups[gr.Name] = percentage;
-
-                    gr.RolloutPercentage = percentage;
-                }
-            }
-
             cumulativeDefaultPercentage = cumulativeDefaultPercentage + audience.DefaultRolloutPercentage;
 
             audience.DefaultRolloutPercentage = cumulativeDefaultPercentage;

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
@@ -65,8 +65,6 @@ namespace Microsoft.FeatureManagement.Assigners
                     nameof(variantAssignmentContext));
             }
 
-            FeatureVariant variant = null;
-
             var lookup = new Dictionary<FeatureVariant, TargetingFilterSettings>();
 
             //
@@ -120,7 +118,7 @@ namespace Microsoft.FeatureManagement.Assigners
                     continue;
                 }
 
-                AccumulateGroups(targetingSettings.Audience, cumulativeGroups);
+                AccumulateGroups(targetingSettings.Audience.Groups, cumulativeGroups);
 
                 if (TargetingEvaluator.IsTargeted(
                     targetingContext,
@@ -163,11 +161,11 @@ namespace Microsoft.FeatureManagement.Assigners
         /// <summary>
         /// Accumulates percentages for groups of an audience.
         /// </summary>
-        /// <param name="audience">The audience that will have its percentages updated based on currently accumulated percentages</param>
+        /// <param name="groups">The groups that will have their percentages updated based on currently accumulated percentages</param>
         /// <param name="cumulativeGroups">The current cumulative rollout percentage for each group</param>
-        private static void AccumulateGroups(Audience audience, Dictionary<string, double> cumulativeGroups)
+        private static void AccumulateGroups(IEnumerable<GroupRollout> groups, Dictionary<string, double> cumulativeGroups)
         {
-            foreach (GroupRollout gr in audience.Groups)
+            foreach (GroupRollout gr in groups)
             {
                 double percentage = gr.RolloutPercentage;
 

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             TargetingFilterSettings settings = context.Parameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
 
-            return Task.FromResult(TargetingEvaluator.IsTargeted(settings, targetingContext, _options.IgnoreCase, context.FeatureName));
+            return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, settings, _options.IgnoreCase, context.FeatureName));
         }
     }
 }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -538,7 +538,11 @@ namespace Tests.FeatureManagement
                 Features.PrecedenceTestingFeature,
                 new TargetingContext
                 {
-                    UserId = "Jeff"
+                    UserId = "Jeff",
+                    Groups = new string[]
+                    {
+                        "Ring0"
+                    }
                 },
                 CancellationToken.None));
         }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -487,6 +487,63 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
+        public async Task TargetingAssignmentPrecedence()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var services = new ServiceCollection();
+
+            services
+                .Configure<FeatureManagementOptions>(options =>
+                {
+                    options.IgnoreMissingFeatureFilters = true;
+                });
+
+            services
+                .AddSingleton(config)
+                .AddFeatureManagement()
+                .AddFeatureVariantAssigner<ContextualTargetingFeatureVariantAssigner>();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IDynamicFeatureManager variantManager = serviceProvider.GetRequiredService<IDynamicFeatureManager>();
+
+            //
+            // Assigned variant by default rollout due to no higher precedence match
+            Assert.Equal("def", await variantManager.GetVariantAsync<string, ITargetingContext>(
+                Features.PrecedenceTestingFeature,
+                new TargetingContext
+                {
+                    UserId = "Patty"
+                },
+                CancellationToken.None));
+
+            //
+            // Assigned variant by group due to higher precedence than default rollout
+            Assert.Equal("ghi", await variantManager.GetVariantAsync<string, ITargetingContext>(
+                Features.PrecedenceTestingFeature,
+                new TargetingContext
+                {
+                    UserId = "Patty",
+                    Groups = new string[]
+                    {
+                        "Ring0"
+                    }
+                },
+                CancellationToken.None));
+
+            //
+            // Assigned variant by user name to higher precedence than default rollout, and group match
+            Assert.Equal("jkl", await variantManager.GetVariantAsync<string, ITargetingContext>(
+                Features.PrecedenceTestingFeature,
+                new TargetingContext
+                {
+                    UserId = "Jeff"
+                },
+                CancellationToken.None));
+        }
+
+        [Fact]
         public async Task AccumulatesAudience()
         {
             IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();

--- a/tests/Tests.FeatureManagement/Features.cs
+++ b/tests/Tests.FeatureManagement/Features.cs
@@ -13,5 +13,6 @@ namespace Tests.FeatureManagement
         public const string VariantFeature = "VariantFeature";
         public const string ContextualVariantFeature = "ContextualVariantFeature";
         public const string ContextualVariantTargetingFeature = "ContextualVariantTargetingFeature";
+        public const string PrecedenceTestingFeature = "PrecedenceTestingFeature";
     }
 }

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -202,11 +202,57 @@
             }
           }
         ]
+      },
+      "PrecedenceTestingFeature": {
+        "Assigner": "Targeting",
+        "Variants": [
+          {
+            "Default": true,
+            "Name": "V1",
+            "ConfigurationReference": "Ref1"
+          },
+          {
+            "Name": "V2",
+            "ConfigurationReference": "Ref2",
+            "AssignmentParameters": {
+              "Audience": {
+                "DefaultRolloutPercentage": 100
+              }
+            }
+          },
+          {
+            "Name": "V3",
+            "ConfigurationReference": "Ref3",
+            "AssignmentParameters": {
+              "Audience": {
+                "Groups": [
+                  {
+                    "Name": "Ring0",
+                    "RolloutPercentage": 100
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Name": "V4",
+            "ConfigurationReference": "Ref4",
+            "AssignmentParameters": {
+              "Audience": {
+                "Users": [
+                  "Jeff"
+                ]
+              }
+            }
+          }
+        ]
       }
     }
   },
   "Ref1": "abc",
   "Ref2": "def",
+  "Ref3": "ghi",
+  "Ref4": "jkl",
   "Percentage15": 15,
   "Percentage35": 35,
   "Percentage50": 50


### PR DESCRIPTION
This PR addresses an issue regarding audience matching precedence when assigning variants via targeting.

If the current user is targeted by name directly, the associated variant should always win. This has the highest precedence.

Next is a group match.

Finally, if none of the above matches occur, default rollout percentage should be used to select a matching variant. Otherwise, the default variant should be selected.

1. User
2. Group
3. Default Rollout
4. Default Variant

This is already detailed in the README, but the existing code did not behave this way.