### PR TITLE
Added capability to cache filter and assignment parameters.

### DIFF
--- a/src/Microsoft.FeatureManagement/AssemblyInfo.cs
+++ b/src/Microsoft.FeatureManagement/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Runtime.CompilerServices;
+
+// Tests
+[assembly: InternalsVisibleTo("Tests.FeatureManagement,PublicKey=" +
+"0024000004800000940000000602000000240000525341310004000001000100895524f60b44ff" +
+"3ae70fbea5662f61dd9d640de2205b7bd5359a43dda006e51d83d1f5f7a7d3f849267a0a28676d" +
+"cf49727a32487d4c75c4aacd5febb0069e1adc66ec63bbd18ec2276091a0e3c1326aa626c9e4db" +
+"800714a134f2a81e405f35752b55220021923429cb61776cd2fa66d25c335f8dc27bb92292905a" +
+"3798d896")]

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureFlagDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureFlagDefinitionProvider.cs
@@ -161,7 +161,9 @@ namespace Microsoft.FeatureManagement
                         enabledFor.Add(new FeatureFilterConfiguration
                         {
                             Name = section[nameof(FeatureFilterConfiguration.Name)],
-                            Parameters = section.GetSection(nameof(FeatureFilterConfiguration.Parameters))
+                            //
+                            // Use wrapper to insure new reference for caching support
+                            Parameters = new ConfigurationWrapper(section.GetSection(nameof(FeatureFilterConfiguration.Parameters)))
                         });
                     }
                 }

--- a/src/Microsoft.FeatureManagement/ConfigurationWrapper.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationWrapper.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Wraps an instance of IConfiguration.
+    /// </summary>
+    class ConfigurationWrapper : IConfiguration
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConfigurationWrapper(IConfiguration configuration)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        public string this[string key] {
+            get => _configuration[key];
+            set => _configuration[key] = value;
+        }
+
+        public IEnumerable<IConfigurationSection> GetChildren() =>
+            _configuration.GetChildren();
+
+        public IChangeToken GetReloadToken() =>
+            _configuration.GetReloadToken();
+
+        public IConfigurationSection GetSection(string key) =>
+            _configuration.GetSection(key);
+    }
+}

--- a/src/Microsoft.FeatureManagement/DynamicFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/DynamicFeatureManager.cs
@@ -240,7 +240,7 @@ namespace Microsoft.FeatureManagement
 
         private void BindSettings(IFeatureVariantAssignerMetadata filter, FeatureVariantAssignmentContext context)
         {
-            IFilterParametersBinder binder = filter as IFilterParametersBinder;
+            IAssignmentParametersBinder binder = filter as IAssignmentParametersBinder;
 
             if (binder == null)
             {

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -19,5 +19,11 @@ namespace Microsoft.FeatureManagement
         /// The settings provided for the feature filter to use when evaluating whether the feature flag should be enabled.
         /// </summary>
         public IConfiguration Parameters { get; set; }
+
+        /// <summary>
+        /// A settings object, if any, that has been pre-bound from <see cref="Parameters"/>.
+        /// The settings are made available for <see cref="IFeatureFilter"/>'s that implement <see cref="IFilterParametersBinder"/>.
+        /// </summary>
+        public object Settings { get; set; }
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     /// A feature filter that can be used to activate a feature based on a random percentage.
     /// </summary>
     [FilterAlias(Alias)]
-    public class PercentageFilter : IFeatureFilter
+    public class PercentageFilter : IFeatureFilter, IFilterParametersBinder
     {
         private const string Alias = "Microsoft.Percentage";
         private readonly ILogger _logger;
@@ -28,6 +28,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         /// <summary>
+        /// Binds configuration representing filter parameters to <see cref="PercentageFilterSettings"/>.
+        /// </summary>
+        /// <param name="filterParameters">The configuration representing filter parameters that should be bound to <see cref="PercentageFilterSettings"/>.</param>
+        /// <returns><see cref="PercentageFilterSettings"/> that can later be used in feature evaluation.</returns>
+        public object BindParameters(IConfiguration filterParameters)
+        {
+            return filterParameters.Get<PercentageFilterSettings>() ?? new PercentageFilterSettings();
+        }
+
+        /// <summary>
         /// Performs a percentage based evaluation to determine whether a feature flag is enabled.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
@@ -35,7 +45,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns>True if the feature flag is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
-            PercentageFilterSettings settings = context.Parameters.Get<PercentageFilterSettings>() ?? new PercentageFilterSettings();
+            PercentageFilterSettings settings = (PercentageFilterSettings)context.Settings;
 
             bool result = true;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     /// A feature filter that can be used to activate a feature flag based on a time window.
     /// </summary>
     [FilterAlias(Alias)]
-    public class TimeWindowFilter : IFeatureFilter
+    public class TimeWindowFilter : IFeatureFilter, IFilterParametersBinder
     {
         private const string Alias = "Microsoft.TimeWindow";
         private readonly ILogger _logger;
@@ -28,6 +28,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         /// <summary>
+        /// Binds configuration representing filter parameters to <see cref="TimeWindowFilterSettings"/>.
+        /// </summary>
+        /// <param name="filterParameters">The configuration representing filter parameters that should be bound to <see cref="TimeWindowFilterSettings"/>.</param>
+        /// <returns><see cref="TimeWindowFilterSettings"/> that can later be used in feature evaluation.</returns>
+        public object BindParameters(IConfiguration filterParameters)
+        {
+            return filterParameters.Get<TimeWindowFilterSettings>() ?? new TimeWindowFilterSettings();
+        }
+
+        /// <summary>
         /// Evaluates whether a feature flag is enabled based on a configurable time window.
         /// </summary>
         /// <param name="context">The feature evaluation context.</param>
@@ -35,7 +45,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns>True if the feature flag is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {
-            TimeWindowFilterSettings settings = context.Parameters.Get<TimeWindowFilterSettings>() ?? new TimeWindowFilterSettings();
+            TimeWindowFilterSettings settings = (TimeWindowFilterSettings)context.Settings;
 
             DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.FeatureManagement/FeatureVariantAssignmentContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureVariantAssignmentContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Collections.Generic;
+
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
@@ -12,5 +14,11 @@ namespace Microsoft.FeatureManagement
         /// The definition of the dynamic feature in need of an assigned variant
         /// </summary>
         public DynamicFeatureDefinition FeatureDefinition { get; set; }
+
+        /// <summary>
+        /// A map of variants and associated assignment settings, if any, that have been pre-bound from <see cref="FeatureVariant.AssignmentParameters"/>.
+        /// The settings are made available for <see cref="IFeatureVariantAssigner"/>'s that implement <see cref="IFilterParametersBinder"/>.
+        /// </summary>
+        public IDictionary<FeatureVariant, object> AssignmentSettings { get; set; }
     }
 }

--- a/src/Microsoft.FeatureManagement/IAssignmentParametersBinder.cs
+++ b/src/Microsoft.FeatureManagement/IAssignmentParametersBinder.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// An interface used by the feature management system to pre-bind feature variant assignment parameters to a settings type.
+    /// <see cref="IFeatureVariantAssigner"/>s can implement this interface to take advantage of caching of settings by the feature management system.
+    /// </summary>
+    public interface IAssignmentParametersBinder
+    {
+        /// <summary>
+        /// Binds feature variant assignment parameters to a settings object.
+        /// </summary>
+        /// <param name="parameters">The configuration representing parameters to bind to a settings object</param>
+        /// <returns>A settings object that is understood by the implementer of <see cref="IAssignmentParametersBinder"/>.</returns>
+        object BindParameters(IConfiguration parameters);
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFilterParametersBinder.cs
+++ b/src/Microsoft.FeatureManagement/IFilterParametersBinder.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// An interface used by the feature management system to pre-bind feature evaluation parameters to a settings type.
+    /// <see cref="IFeatureFilter"/>s and <see cref="IFeatureVariantAssigner"/>s can implement this interface 
+    /// to take advantage of caching of settings by the feature management system.
+    /// </summary>
+    public interface IFilterParametersBinder
+    {
+        /// <summary>
+        /// Binds a set of feature filter parameters or assignment parameters to a settings object.
+        /// </summary>
+        /// <param name="parameters">The configuration representing parameters to bind to a settings object</param>
+        /// <returns>A settings object that is understood by the implementer of <see cref="IFilterParametersBinder"/>.</returns>
+        object BindParameters(IConfiguration parameters);
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFilterParametersBinder.cs
+++ b/src/Microsoft.FeatureManagement/IFilterParametersBinder.cs
@@ -6,16 +6,15 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// An interface used by the feature management system to pre-bind feature evaluation parameters to a settings type.
-    /// <see cref="IFeatureFilter"/>s and <see cref="IFeatureVariantAssigner"/>s can implement this interface 
-    /// to take advantage of caching of settings by the feature management system.
+    /// An interface used by the feature management system to pre-bind feature filter parameters to a settings type.
+    /// <see cref="IFeatureFilter"/>s can implement this interface to take advantage of caching of settings by the feature management system.
     /// </summary>
     public interface IFilterParametersBinder
     {
         /// <summary>
-        /// Binds a set of feature filter parameters or assignment parameters to a settings object.
+        /// Binds a set of feature filter parameters to a settings object.
         /// </summary>
-        /// <param name="parameters">The configuration representing parameters to bind to a settings object</param>
+        /// <param name="parameters">The configuration representing filter parameters to bind to a settings object</param>
         /// <returns>A settings object that is understood by the implementer of <see cref="IFilterParametersBinder"/>.</returns>
         object BindParameters(IConfiguration parameters);
     }

--- a/src/Microsoft.FeatureManagement/Microsoft.FeatureManagement.csproj
+++ b/src/Microsoft.FeatureManagement/Microsoft.FeatureManagement.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.23" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFeatureVariantAssigner.cs
@@ -16,7 +16,7 @@ namespace Microsoft.FeatureManagement.Assigners
     /// A feature variant assigner that can be used to assign a variant based on targeted audiences.
     /// </summary>
     [AssignerAlias(Alias)]
-    public class ContextualTargetingFeatureVariantAssigner : IContextualFeatureVariantAssigner<ITargetingContext>, IFilterParametersBinder
+    public class ContextualTargetingFeatureVariantAssigner : IContextualFeatureVariantAssigner<ITargetingContext>, IAssignmentParametersBinder
     {
         private const string Alias = "Microsoft.Targeting";
         private readonly TargetingEvaluationOptions _options;

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     /// A feature filter that can be used to activate feature flags for targeted audiences.
     /// </summary>
     [FilterAlias(Alias)]
-    public class ContextualTargetingFilter : IContextualFeatureFilter<ITargetingContext>
+    public class ContextualTargetingFilter : IContextualFeatureFilter<ITargetingContext>, IFilterParametersBinder
     {
         private const string Alias = "Microsoft.Targeting";
         private readonly TargetingEvaluationOptions _options;
@@ -26,6 +26,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         public ContextualTargetingFilter(IOptions<TargetingEvaluationOptions> options)
         {
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        /// <summary>
+        /// Binds configuration representing filter parameters to <see cref="TargetingFilterSettings"/>.
+        /// </summary>
+        /// <param name="filterParameters">The configuration representing filter parameters that should be bound to <see cref="TargetingFilterSettings"/>.</param>
+        /// <returns><see cref="TargetingFilterSettings"/> that can later be used in targeting.</returns>
+        public object BindParameters(IConfiguration filterParameters)
+        {
+            return filterParameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
         }
 
         /// <summary>
@@ -48,9 +58,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 throw new ArgumentNullException(nameof(targetingContext));
             }
 
-            TargetingFilterSettings settings = context.Parameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
-
-            return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, settings, _options.IgnoreCase, context.FeatureFlagName));
+            return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, (TargetingFilterSettings)context.Settings, _options.IgnoreCase, context.FeatureFlagName));
         }
     }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFeatureVariantAssigner.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement.FeatureFilters;
@@ -14,7 +15,7 @@ namespace Microsoft.FeatureManagement.Assigners
     /// A feature variant assigner that can be used to assign a variant based on targeted audiences.
     /// </summary>
     [AssignerAlias(Alias)]
-    public class TargetingFeatureVariantAssigner : IFeatureVariantAssigner
+    public class TargetingFeatureVariantAssigner : IFeatureVariantAssigner, IFilterParametersBinder
     {
         private const string Alias = "Microsoft.Targeting";
         private readonly ITargetingContextAccessor _contextAccessor;
@@ -63,6 +64,16 @@ namespace Microsoft.FeatureManagement.Assigners
             }
 
             return await _contextualResolver.AssignVariantAsync(variantAssignmentContext, targetingContext, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Binds configuration representing assignment parameters to <see cref="TargetingFilterSettings"/>.
+        /// </summary>
+        /// <param name="assignmentParameters">The configuration representing assignment parameters that should be bound to <see cref="TargetingFilterSettings"/>.</param>
+        /// <returns><see cref="TargetingFilterSettings"/> that can later be used in targeting assigment.</returns>
+        public object BindParameters(IConfiguration assignmentParameters)
+        {
+            return assignmentParameters.Get<TargetingFilterSettings>();
         }
     }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFeatureVariantAssigner.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFeatureVariantAssigner.cs
@@ -15,7 +15,7 @@ namespace Microsoft.FeatureManagement.Assigners
     /// A feature variant assigner that can be used to assign a variant based on targeted audiences.
     /// </summary>
     [AssignerAlias(Alias)]
-    public class TargetingFeatureVariantAssigner : IFeatureVariantAssigner, IFilterParametersBinder
+    public class TargetingFeatureVariantAssigner : IFeatureVariantAssigner, IAssignmentParametersBinder
     {
         private const string Alias = "Microsoft.Targeting";
         private readonly ITargetingContextAccessor _contextAccessor;

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -13,7 +14,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     /// A feature filter that can be used to activate feature flags for targeted audiences.
     /// </summary>
     [FilterAlias(Alias)]
-    public class TargetingFilter : IFeatureFilter
+    public class TargetingFilter : IFeatureFilter, IFilterParametersBinder
     {
         private const string Alias = "Microsoft.Targeting";
         private readonly ITargetingContextAccessor _contextAccessor;
@@ -31,6 +32,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
             _contextualFilter = new ContextualTargetingFilter(options);
             _logger = loggerFactory?.CreateLogger<TargetingFilter>() ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        /// <summary>
+        /// Binds configuration representing filter parameters to <see cref="TargetingFilterSettings"/>.
+        /// </summary>
+        /// <param name="filterParameters">The configuration representing filter parameters that should be bound to <see cref="TargetingFilterSettings"/>.</param>
+        /// <returns><see cref="TargetingFilterSettings"/> that can later be used in targeting.</returns>
+        public object BindParameters(IConfiguration filterParameters)
+        {
+            return filterParameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
         }
 
         /// <summary>

--- a/tests/Tests.FeatureManagement/TestAssigner.cs
+++ b/tests/Tests.FeatureManagement/TestAssigner.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
 {
-    class TestAssigner : IFeatureVariantAssigner, IFilterParametersBinder
+    class TestAssigner : IFeatureVariantAssigner, IAssignmentParametersBinder
     {
         public Func<FeatureVariantAssignmentContext, FeatureVariant> Callback { get; set; }
 

--- a/tests/Tests.FeatureManagement/TestAssigner.cs
+++ b/tests/Tests.FeatureManagement/TestAssigner.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
 using System.Threading;
@@ -8,9 +9,21 @@ using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
 {
-    class TestAssigner : IFeatureVariantAssigner
+    class TestAssigner : IFeatureVariantAssigner, IFilterParametersBinder
     {
         public Func<FeatureVariantAssignmentContext, FeatureVariant> Callback { get; set; }
+
+        public Func<IConfiguration, object> ParametersBinderCallback { get; set; }
+
+        public object BindParameters(IConfiguration parameters)
+        {
+            if (ParametersBinderCallback != null)
+            {
+                return ParametersBinderCallback(parameters);
+            }
+
+            return parameters;
+        }
 
         public ValueTask<FeatureVariant> AssignVariantAsync(FeatureVariantAssignmentContext variantAssignmentContext, CancellationToken cancellationToken)
         {

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using System;
 using System.Threading;
@@ -8,9 +9,21 @@ using System.Threading.Tasks;
 
 namespace Tests.FeatureManagement
 {
-    class TestFilter : IFeatureFilter
+    class TestFilter : IFeatureFilter, IFilterParametersBinder
     {
+        public Func<IConfiguration, object> ParametersBinderCallback { get; set; }
+
         public Func<FeatureFilterEvaluationContext, Task<bool>> Callback { get; set; }
+
+        public object BindParameters(IConfiguration parameters)
+        {
+            if (ParametersBinderCallback != null)
+            {
+                return ParametersBinderCallback(parameters);
+            }
+
+            return parameters;
+        }
 
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
         {

--- a/tests/Tests.FeatureManagement/Tests.FeatureManagement.csproj
+++ b/tests/Tests.FeatureManagement/Tests.FeatureManagement.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
+	<DelaySign>false</DelaySign>
+	<SignAssembly>true</SignAssembly>
+	<AssemblyOriginatorKeyFile>..\..\build\Microsoft.FeatureManagement.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a filter parameters binder interface to allow feature manager to cache bound feature filter and feature variant assignment parameters for performance optimization.

### Why

Feature filters are given filter parameters in the form of `IConfiguration` that instruct them how to perform feature evaluation. Often these parameters are bound to a strongly typed settings object before use. Observed cost of binding `IConfiguration` to perform feature evaluation is high. By caching the result of the binding, a noticeable performance increase can be achieved. This PR gives Implementers of IFeatureFilter and IFeatureVariantAssigner the option to take cache these settings with the help of the feature management system. This is possible through the `IFilterParametersBinder` and `IAssignmentParametersBinder` interfaces.

``` c#
/// <summary>
/// An interface used by the feature management system to pre-bind feature filter parameters to a settings type.
/// <see cref="IFeatureFilter"/>s can implement this interface to take advantage of caching of settings by the feature management system.
/// </summary>
public interface IFilterParametersBinder
{
    /// <summary>
    /// Binds a set of feature filter parameters to a settings object.
    /// </summary>
    /// <param name="parameters">The configuration representing filter parameters to bind to a settings object</param>
    /// <returns>A settings object that is understood by the implementer of <see cref="IFilterParametersBinder"/>.</returns>
    object BindParameters(IConfiguration parameters);
}
```

### Example Usage

``` c#
class MyFilter : IFeatureFilter, IFilterParametersBinder
{
    public object BindParameters(IConfiguration filterParameters)
    {
        //
        // Called before evaluation occurs, only if settings are not already in cache.
        return filterParameters.Get<FilterSettings>();
    }

    public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, CancellationToken cancellationToken)
    {
        //
        // Get pre-bound/cached settings
        FilterSettings settings = (FilterSettings)context.Settings;

        //
        // Use them for evaluation
        ...
    }
}
```

### Breaking Change

This PR introduces a possible breaking change for custom feature definition providers that implement `IFeatureFlagDefinitionProvider` or `IDynamicFeatureDefinitionProvider`. To ensure that any filters that implement `IFilterParametersBinder` see updates to feature filter parameters or feature variant assignment parameters when they are changed, definition providers should ensure a new object reference is used for the parameters in the feature definition. Otherwise, the filters will continue to use the same settings from the cache.

### Perf

Rough performance assessment showed improvements of ~100 times at least for complex settings objects.