### PR TITLE
Update Azure App Configuration provider reference in example project to pull features using v2 schema.

### DIFF
--- a/examples/FeatureFlagDemo/FeatureFlagDemo.csproj
+++ b/examples/FeatureFlagDemo/FeatureFlagDemo.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.1.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/FeatureFlagDemo/Program.cs
+++ b/examples/FeatureFlagDemo/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +13,10 @@ namespace FeatureFlagDemo
     {
         public static void Main(string[] args)
         {
+            //
+            // Opt-in to use new schema with features received from Azure App Configuration
+            Environment.SetEnvironmentVariable("AZURE_APP_CONFIGURATION_FEATURE_MANAGEMENT_SCHEMA_VERSION", "2");
+
             CreateWebHostBuilder(args).Build().Run();
         }
 

--- a/examples/FeatureFlagDemo/Startup.cs
+++ b/examples/FeatureFlagDemo/Startup.cs
@@ -63,6 +63,8 @@ namespace FeatureFlagDemo
                     .AddFeatureVariantAssigner<TargetingFeatureVariantAssigner>()
                     .UseDisabledFeaturesHandler(new FeatureNotEnabledDisabledHandler());
 
+            services.AddAzureAppConfiguration();
+
             services.AddMvc(o =>
             {
                 o.Filters.AddForFeature<ThirdPartyActionFilter>(nameof(MyFeatureFlags.EnhancedPipeline));


### PR DESCRIPTION
Update Azure App Configuration provider reference in example project to pull features using v2 schema.