### PR TITLE
Throw exception if feature management schemas are mixed to avoid unintentionally hiding feature flags.

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationDynamicFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationDynamicFeatureDefinitionProvider.cs
@@ -19,8 +19,8 @@ namespace Microsoft.FeatureManagement
     /// </summary>
     sealed class ConfigurationDynamicFeatureDefinitionProvider : IDynamicFeatureDefinitionProvider, IDisposable
     {
+        public const string DynamicFeatureDefinitionsSectionName = "DynamicFeatures";
         private const string FeatureManagementSectionName = "FeatureManagement";
-        private const string DynamicFeatureDefinitionsSectionName= "DynamicFeatures";
         private const string FeatureVariantsSectionName = "Variants";
         private readonly IConfiguration _configuration;
         private readonly ConcurrentDictionary<string, DynamicFeatureDefinition> _dynamicFeatureDefinitions;

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureFlagDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureFlagDefinitionProvider.cs
@@ -187,6 +187,18 @@ namespace Microsoft.FeatureManagement
             IConfigurationSection featureFlagsSection = featureManagementChildren.FirstOrDefault(s => s.Key == FeatureFlagDefinitionsSectionName);
 
             //
+            // Check for mixed schema to avoid confusing scenario where feature flags defined in separate sources with different schemas don't mix.
+            if (featureFlagsSection != null &&
+                featureManagementChildren.Any(section =>
+                    !section.Key.Equals(FeatureFlagDefinitionsSectionName) &&
+                    !section.Key.Equals(ConfigurationDynamicFeatureDefinitionProvider.DynamicFeatureDefinitionsSectionName)))
+            {
+                throw new FeatureManagementException(
+                    FeatureManagementError.InvalidConfiguration,
+                    "Detected feature flags defined using different feature management schemas.");
+            }
+
+            //
             // Support backward compatability where feature flag definitions were directly under the feature management section
             return featureFlagsSection == null ?
                 featureManagementChildren :

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -61,6 +61,11 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// A dynamic feature does not have a default feature variant configured.
         /// </summary>
-        MissingDefaultFeatureVariant
+        MissingDefaultFeatureVariant,
+
+        /// <summary>
+        /// A configuration error is present in the feature management system.
+        /// </summary>
+        InvalidConfiguration
     }
 }


### PR DESCRIPTION
The v3 library adds a new schema for defining feature flags. The feature manager only reads feature flags using a single schema. If different feature flag sources such as multiple appsettings files, or a file and a feature flag provider are mixed and using different schemas it could cause feature flags to be hidden. 

In order to prevent a hard to troubleshoot situation where feature flags are not being found due to mixed schemas, this PR updates the feature management system to throw an exception if feature management schemas are mixed.