### PR TITLE
Allow a feature flag to require all registered feature filters be enabled.

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFlagDefinition.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFlagDefinition.cs
@@ -20,5 +20,11 @@ namespace Microsoft.FeatureManagement
         /// The feature filters that the feature flag can be enabled for.
         /// </summary>
         public IEnumerable<FeatureFilterConfiguration> EnabledFor { get; set; } = Enumerable.Empty<FeatureFilterConfiguration>();
+
+        /// <summary>
+        /// Determines whether any or all registered feature filters must be enabled for the feature to be considered enabled
+        /// The default value is <see cref="RequirementType.Any"/>.
+        /// </summary>
+        public RequirementType RequirementType { get; set; } = RequirementType.Any;
     }
 }

--- a/src/Microsoft.FeatureManagement/RequirementType.cs
+++ b/src/Microsoft.FeatureManagement/RequirementType.cs
@@ -4,16 +4,16 @@
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// Describes whether any or all features in a given set should be required to be considered enabled.
+    /// Describes whether any or all conditions in a set should be required to be true.
     /// </summary>
     public enum RequirementType
     {
         /// <summary>
-        /// The enabled state will be attained if any feature in the set is enabled.
+        /// The set of conditions will be evaluated as true if any condition in the set is true.
         /// </summary>
         Any,
         /// <summary>
-        /// The enabled state will be attained if all features in the set are enabled.
+        /// The set of conditions will be evaluated as true if all the conditions in the set are true.
         /// </summary>
         All
     }

--- a/tests/Tests.FeatureManagement/TestFilter.cs
+++ b/tests/Tests.FeatureManagement/TestFilter.cs
@@ -17,4 +17,10 @@ namespace Tests.FeatureManagement
             return Callback?.Invoke(context) ?? Task.FromResult(false);
         }
     }
+
+    //
+    // Offers the same functionality as TestFilter, but allows a feature used in tests to reference two different filters
+    class Test2Filter : TestFilter
+    {
+    }
 }

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -1,259 +1,286 @@
 {
-  "FeatureManagement": {
-    "FeatureFlags": {
-      "OnTestFeature": true,
-      "OffTestFeature": false,
-      "ConditionalFeature": {
-        "EnabledFor": [
-          {
-            "Name": "Test",
-            "Parameters": {
-              "P1": "V1"
+    "FeatureManagement": {
+        "FeatureFlags": {
+            "OnTestFeature": true,
+            "OffTestFeature": false,
+            "ConditionalFeature": {
+                "EnabledFor": [
+                    {
+                        "Name": "Test",
+                        "Parameters": {
+                            "P1": "V1"
+                        }
+                    }
+                ]
+            },
+            "TargetingTestFeature": {
+                "EnabledFor": [
+                    {
+                        "Name": "Targeting",
+                        "Parameters": {
+                            "Audience": {
+                                "Users": [
+                                    "Jeff",
+                                    "Alicia"
+                                ],
+                                "Groups": [
+                                    {
+                                        "Name": "Ring0",
+                                        "RolloutPercentage": 100
+                                    },
+                                    {
+                                        "Name": "Ring1",
+                                        "RolloutPercentage": 50
+                                    }
+                                ],
+                                "DefaultRolloutPercentage": 20
+                            }
+                        }
+                    }
+                ]
+            },
+            "ConditionalFeature2": {
+                "EnabledFor": [
+                    {
+                        "Name": "Test"
+                    }
+                ]
+            },
+            "WithSuffixFeature": {
+                "EnabledFor": [
+                    {
+                        "Name": "TestFilter",
+                        "Parameters": {
+                        }
+                    }
+                ]
+            },
+            "WithoutSuffixFeature": {
+                "EnabledFor": [
+                    {
+                        "Name": "Test",
+                        "Parameters": {
+                        }
+                    }
+                ]
+            },
+            "ContextualFeature": {
+                "EnabledFor": [
+                    {
+                        "Name": "ContextualTest",
+                        "Parameters": {
+                            "AllowedAccounts": [
+                                "abc"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "AnyFilterFeature": {
+                "RequirementType": "Any",
+                "EnabledFor": [
+                    {
+                        "Name": "Test",
+                        "Parameters": {}
+                    },
+                    {
+                        "Name": "Test2",
+                        "Parameters": {}
+                    }
+                ]
+            },
+            "AllFiltersFeature": {
+                "RequirementType": "All",
+                "EnabledFor": [
+                    {
+                        "Name": "Test",
+                        "Parameters": {}
+                    },
+                    {
+                        "Name": "Test2",
+                        "Parameters": {}
+                    }
+                ]
+
             }
-          }
-        ]
-      },
-      "TargetingTestFeature": {
-        "EnabledFor": [
-          {
-            "Name": "Targeting",
-            "Parameters": {
-              "Audience": {
-                "Users": [
-                  "Jeff",
-                  "Alicia"
-                ],
-                "Groups": [
-                  {
-                    "Name": "Ring0",
-                    "RolloutPercentage": 100
-                  },
-                  {
-                    "Name": "Ring1",
-                    "RolloutPercentage": 50
-                  }
-                ],
-                "DefaultRolloutPercentage": 20
-              }
+        },
+        "DynamicFeatures": {
+            "VariantFeature": {
+                "Assigner": "Test",
+                "Variants": [
+                    {
+                        "Default": true,
+                        "Name": "V1",
+                        "ConfigurationReference": "Ref1"
+                    },
+                    {
+                        "Name": "V2",
+                        "ConfigurationReference": "Ref2",
+                        "AssignmentParameters": {
+                            "P1": "V1"
+                        }
+                    }
+                ]
+            },
+            "ContextualVariantFeature": {
+                "Assigner": "ContextualTest",
+                "Variants": [
+                    {
+                        "Default": true,
+                        "Name": "V1",
+                        "ConfigurationReference": "Ref1"
+                    },
+                    {
+                        "Name": "V2",
+                        "ConfigurationReference": "Ref2",
+                        "AssignmentParameters": {
+                            "AllowedAccounts": [
+                                "abc"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "ContextualVariantTargetingFeature": {
+                "Assigner": "Targeting",
+                "Variants": [
+                    {
+                        "Default": true,
+                        "Name": "V1",
+                        "ConfigurationReference": "Ref1"
+                    },
+                    {
+                        "Name": "V2",
+                        "ConfigurationReference": "Ref2",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "Users": [
+                                    "Jeff"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            },
+            "AccumulatedTargetingFeature": {
+                "Assigner": "Targeting",
+                "Variants": [
+                    {
+                        "Default": true,
+                        "Name": "V1",
+                        "ConfigurationReference": "Percentage15"
+                    },
+                    {
+                        "Name": "V2",
+                        "ConfigurationReference": "Percentage35",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "DefaultRolloutPercentage": 35
+                            }
+                        }
+                    },
+                    {
+                        "Name": "V3",
+                        "ConfigurationReference": "Percentage50",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "DefaultRolloutPercentage": 50
+                            }
+                        }
+                    }
+                ]
+            },
+            "AccumulatedGroupsTargetingFeature": {
+                "Assigner": "Targeting",
+                "Variants": [
+                    {
+                        "Default": true,
+                        "Name": "V1",
+                        "ConfigurationReference": "Percentage15"
+                    },
+                    {
+                        "Name": "V2",
+                        "ConfigurationReference": "Percentage35",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "Groups": [
+                                    {
+                                        "Name": "r",
+                                        "RolloutPercentage": 35
+                                    }
+                                ],
+                                "DefaultRolloutPercentage": 0
+                            }
+                        }
+                    },
+                    {
+                        "Name": "V3",
+                        "ConfigurationReference": "Percentage50",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "Groups": [
+                                    {
+                                        "Name": "r",
+                                        "RolloutPercentage": 50
+                                    }
+                                ],
+                                "DefaultRolloutPercentage": 0
+                            }
+                        }
+                    }
+                ]
+            },
+            "PrecedenceTestingFeature": {
+                "Assigner": "Targeting",
+                "Variants": [
+                    {
+                        "Default": true,
+                        "Name": "V1",
+                        "ConfigurationReference": "Ref1"
+                    },
+                    {
+                        "Name": "V2",
+                        "ConfigurationReference": "Ref2",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "DefaultRolloutPercentage": 100
+                            }
+                        }
+                    },
+                    {
+                        "Name": "V3",
+                        "ConfigurationReference": "Ref3",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "Groups": [
+                                    {
+                                        "Name": "Ring0",
+                                        "RolloutPercentage": 100
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "V4",
+                        "ConfigurationReference": "Ref4",
+                        "AssignmentParameters": {
+                            "Audience": {
+                                "Users": [
+                                    "Jeff"
+                                ]
+                            }
+                        }
+                    }
+                ]
             }
-          }
-        ]
-      },
-      "ConditionalFeature2": {
-        "EnabledFor": [
-          {
-            "Name": "Test"
-          }
-        ]
-      },
-      "WithSuffixFeature": {
-        "EnabledFor": [
-          {
-            "Name": "TestFilter",
-            "Parameters": {
-            }
-          }
-        ]
-      },
-      "WithoutSuffixFeature": {
-        "EnabledFor": [
-          {
-            "Name": "Test",
-            "Parameters": {
-            }
-          }
-        ]
-      },
-      "ContextualFeature": {
-        "EnabledFor": [
-          {
-            "Name": "ContextualTest",
-            "Parameters": {
-              "AllowedAccounts": [
-                "abc"
-              ]
-            }
-          }
-        ]
-      }
+        }
     },
-    "DynamicFeatures": {
-      "VariantFeature": {
-        "Assigner": "Test",
-        "Variants": [
-          {
-            "Default": true,
-            "Name": "V1",
-            "ConfigurationReference": "Ref1"
-          },
-          {
-            "Name": "V2",
-            "ConfigurationReference": "Ref2",
-            "AssignmentParameters": {
-              "P1": "V1"
-            }
-          }
-        ]
-      },
-      "ContextualVariantFeature": {
-        "Assigner": "ContextualTest",
-        "Variants": [
-          {
-            "Default": true,
-            "Name": "V1",
-            "ConfigurationReference": "Ref1"
-          },
-          {
-            "Name": "V2",
-            "ConfigurationReference": "Ref2",
-            "AssignmentParameters": {
-              "AllowedAccounts": [
-                "abc"
-              ]
-            }
-          }
-        ]
-      },
-      "ContextualVariantTargetingFeature": {
-        "Assigner": "Targeting",
-        "Variants": [
-          {
-            "Default": true,
-            "Name": "V1",
-            "ConfigurationReference": "Ref1"
-          },
-          {
-            "Name": "V2",
-            "ConfigurationReference": "Ref2",
-            "AssignmentParameters": {
-              "Audience": {
-                "Users": [
-                  "Jeff"
-                ]
-              }
-            }
-          }
-        ]
-      },
-      "AccumulatedTargetingFeature": {
-        "Assigner": "Targeting",
-        "Variants": [
-          {
-            "Default": true,
-            "Name": "V1",
-            "ConfigurationReference": "Percentage15"
-          },
-          {
-            "Name": "V2",
-            "ConfigurationReference": "Percentage35",
-            "AssignmentParameters": {
-              "Audience": {
-                "DefaultRolloutPercentage": 35
-              }
-            }
-          },
-          {
-            "Name": "V3",
-            "ConfigurationReference": "Percentage50",
-            "AssignmentParameters": {
-              "Audience": {
-                "DefaultRolloutPercentage": 50
-              }
-            }
-          }
-        ]
-      },
-      "AccumulatedGroupsTargetingFeature": {
-        "Assigner": "Targeting",
-        "Variants": [
-          {
-            "Default": true,
-            "Name": "V1",
-            "ConfigurationReference": "Percentage15"
-          },
-          {
-            "Name": "V2",
-            "ConfigurationReference": "Percentage35",
-            "AssignmentParameters": {
-              "Audience": {
-                "Groups": [
-                  {
-                    "Name": "r",
-                    "RolloutPercentage": 35
-                  }
-                ],
-                "DefaultRolloutPercentage": 0
-              }
-            }
-          },
-          {
-            "Name": "V3",
-            "ConfigurationReference": "Percentage50",
-            "AssignmentParameters": {
-              "Audience": {
-                "Groups": [
-                  {
-                    "Name": "r",
-                    "RolloutPercentage": 50
-                  }
-                ],
-                "DefaultRolloutPercentage": 0
-              }
-            }
-          }
-        ]
-      },
-      "PrecedenceTestingFeature": {
-        "Assigner": "Targeting",
-        "Variants": [
-          {
-            "Default": true,
-            "Name": "V1",
-            "ConfigurationReference": "Ref1"
-          },
-          {
-            "Name": "V2",
-            "ConfigurationReference": "Ref2",
-            "AssignmentParameters": {
-              "Audience": {
-                "DefaultRolloutPercentage": 100
-              }
-            }
-          },
-          {
-            "Name": "V3",
-            "ConfigurationReference": "Ref3",
-            "AssignmentParameters": {
-              "Audience": {
-                "Groups": [
-                  {
-                    "Name": "Ring0",
-                    "RolloutPercentage": 100
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "Name": "V4",
-            "ConfigurationReference": "Ref4",
-            "AssignmentParameters": {
-              "Audience": {
-                "Users": [
-                  "Jeff"
-                ]
-              }
-            }
-          }
-        ]
-      }
-    }
-  },
-  "Ref1": "abc",
-  "Ref2": "def",
-  "Ref3": "ghi",
-  "Ref4": "jkl",
-  "Percentage15": 15,
-  "Percentage35": 35,
-  "Percentage50": 50
+    "Ref1": "abc",
+    "Ref2": "def",
+    "Ref3": "ghi",
+    "Ref4": "jkl",
+    "Percentage15": 15,
+    "Percentage35": 35,
+    "Percentage50": 50
 }


### PR DESCRIPTION
In response to #28.

## Combine feature filters with AND

By default, feature filters are evaluated using a logical OR operation. If any feature filter that is registered for a feature is enabled, then the feature is considered to be enabled. This PR adds the capability to customize this so that feature filters are combined with a logical AND operation. This means all registered feature filters would need to be enabled for the feature to be considered enabled.

### Configuration

Overriding feature filter evaluation to use AND can be done by specifying the `RequirementType` for a given feature flag.

**RequirementType**
* **Any**: Default. If any feature filter is enabled, the feature will be considered enabled.
* **All**: Requires all feature filters to be enabled to enable a feature

```json
{
    "FeatureManagement": {
        "FeatureFlags": {
            "MyAndFeature": {
                "RequirementType": "All",
                "EnabledFor": [
                    {
                        "Name": "Test",
                        "Parameters": {}
                    },
                    {
                        "Name": "Test2",
                        "Parameters": {}
                    }
                ]
            }
        }
    }
}
```
