### PR TITLE
Adds exclude logic to Targeting and Audience, adds unit test, updates example to include exclude

### DIFF
--- a/examples/TargetingConsoleApp/Identity/InMemoryUserRepository.cs
+++ b/examples/TargetingConsoleApp/Identity/InMemoryUserRepository.cs
@@ -74,6 +74,19 @@ namespace Consoto.Banking.AccountService.Identity
                     "TeamMembers"
                 }
             },
+            new User
+            {
+                Id = "Anne",
+                Groups = Enumerable.Empty<string>()
+            },
+            new User
+            {
+                Id = "Chuck",
+                Groups =  new List<string>()
+                {
+                    "Contractor"
+                }
+            },
         };
 
         public Task<User> GetUser(string id)

--- a/examples/TargetingConsoleApp/appsettings.json
+++ b/examples/TargetingConsoleApp/appsettings.json
@@ -7,7 +7,8 @@
           "Parameters": {
             "Audience": {
               "Users": [
-                "Jeff"
+                "Jeff",
+                "Anne"
               ],
               "Groups": [
                 {
@@ -19,7 +20,16 @@
                   "RolloutPercentage": 45
                 }
               ],
-              "DefaultRolloutPercentage": 20
+              "DefaultRolloutPercentage": 20,
+              "Exclusion": {
+                "Users": [
+                  "Anne",
+                  "Phil"
+                ],
+                "Groups": [
+                  "Contractor"
+                ]
+              }
             }
           }
         }

--- a/src/Microsoft.FeatureManagement/Targeting/Audience.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/Audience.cs
@@ -24,5 +24,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// Includes users in the audience based off a percentage of the total possible audience. Valid values range from 0 to 100 inclusive.
         /// </summary>
         public double DefaultRolloutPercentage { get; set; }
+
+        /// <summary>
+        /// Excludes a basic audience from this audience.
+        /// </summary>
+        public BasicAudience Exclusion { get; set; }
     }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/BasicAudience.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/BasicAudience.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Collections.Generic;
+
+namespace Microsoft.FeatureManagement.FeatureFilters
+{
+    /// <summary>
+    /// A basic audience definition describing a set of users and groups.
+    /// </summary>
+    public class BasicAudience
+	{
+        /// <summary>
+        /// Includes users in the audience by name.
+        /// </summary>
+        public List<string> Users { get; set; }
+
+        /// <summary>
+        /// Includes users in the audience by group name.
+        /// </summary>
+        public List<string> Groups { get; set; }
+	}
+}

--- a/src/Microsoft.FeatureManagement/Targeting/BasicAudience.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/BasicAudience.cs
@@ -9,7 +9,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
     /// A basic audience definition describing a set of users and groups.
     /// </summary>
     public class BasicAudience
-	{
+    {
         /// <summary>
         /// Includes users in the audience by name.
         /// </summary>
@@ -19,5 +19,5 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// Includes users in the audience by group name.
         /// </summary>
         public List<string> Groups { get; set; }
-	}
+    }
 }

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -35,6 +35,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         }
 
         private StringComparison ComparisonType => _options.IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        private StringComparer ComparerType => _options.IgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
         /// <summary>
         /// Performs a targeting evaluation using the provided <see cref="TargetingContext"/> to determine if a feature should be enabled.
@@ -77,7 +78,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 // Check if the user is in a group within exclusion
                 if (targetingContext.Groups != null &&
                     settings.Audience.Exclusion.Groups != null &&
-                    settings.Audience.Exclusion.Groups.Any(group => targetingContext.Groups.Any(targetingGroup => targetingGroup.Equals(group, ComparisonType))))
+                    settings.Audience.Exclusion.Groups.Any(group => targetingContext.Groups.Contains(group, ComparerType)))
                 {
                     return Task.FromResult(false);
                 }

--- a/tests/Tests.FeatureManagement/Features.cs
+++ b/tests/Tests.FeatureManagement/Features.cs
@@ -6,6 +6,7 @@ namespace Tests.FeatureManagement
     enum Features
     {
         TargetingTestFeature,
+        TargetingTestFeatureWithExclusion,
         OnTestFeature,
         OffTestFeature,
         ConditionalFeature,

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -35,6 +35,41 @@
         }
       ]
     },
+    "TargetingTestFeatureWithExclusion": {
+      "EnabledFor": [
+        {
+          "Name": "Targeting",
+          "Parameters": {
+            "Audience": {
+              "Users": [
+                "Jeff",
+                "Alicia"
+              ],
+              "Groups": [
+                {
+                  "Name": "Ring0",
+                  "RolloutPercentage": 100
+                },
+                {
+                  "Name": "Ring1",
+                  "RolloutPercentage": 50
+                }
+              ],
+              "DefaultRolloutPercentage": 20,
+              "Exclusion": {
+                "Users": [
+                  "Jeff"
+                ],
+                "Groups": [
+                  "Ring0",
+                  "Ring2"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
     "ConditionalFeature": {
       "EnabledFor": [
         {


### PR DESCRIPTION
In response to #123.

# Adds Exclusion to Audience
Audiences have historically been a list of users, groups, and rollout percentages. This change adds an additional field in Audience called **Exclusion**. This field holds a list of **Users** and **Groups**. These users and groups are evaluated before the rest of the Audience. If there is a match, the feature flag immediately returns false. 

If the targeting filter has sibling filters, they will still be evaluated after a false result.

# Example
`appsettings.json`
```json
{
  "Name": "Targeting",
  "Parameters": {
    "Audience": {
      "Users": [
        "Jeff",
        "Anne"
      ],
      "Groups": [
        {
          "Name": "Management",
          "RolloutPercentage": 100
        },
        {
          "Name": "TeamMembers",
          "RolloutPercentage": 45
        }
      ],
      "DefaultRolloutPercentage": 20,
      "Exclusion": {
        "Users": [
          "Anne",
          "Phil"
        ],
        "Groups": [
          "Contractor"
        ]
      }
    }
  }
}
```

`Evaluation`
```csharp
.IsEnabledAsync(betaFeature, new TargetingContext { UserId = "Anne" }}) // returns false
.IsEnabledAsync(betaFeature, new TargetingContext { UserId = "Phil", Groups = new List<string>() { "Management" }}}) // returns false
.IsEnabledAsync(betaFeature, new TargetingContext { UserId = "Bill", Groups = new List<string>() { "Contractor" }}}) // returns false
.IsEnabledAsync(betaFeature, new TargetingContext { UserId = "Bill", Groups = new List<string>() { "Management", "Contractor" }}}) // returns false
```