### PR TITLE
Adds Requirement Type All and Any to FeatureFlags

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -162,7 +162,7 @@ namespace Microsoft.FeatureManagement
                 {
                     if (!Enum.TryParse(rawRequirementType, true, out requirementType))
                     {
-                        throw new ArgumentException($"Invalid requirement type '{rawRequirementType}' for feature '{configurationSection.Key}'.");
+                        throw new FeatureManagementException(FeatureManagementError.InvalidConfiguration, $"Invalid requirement type '{rawRequirementType}' for feature '{configurationSection.Key}'.");
                     }
                 }
 

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -158,12 +158,13 @@ namespace Microsoft.FeatureManagement
             {
                 string rawRequirementType = configurationSection[RequirementTypeKeyword];
 
-                if (!string.IsNullOrEmpty(rawRequirementType))
+                //
+                // If requirement type is specified, parse it and set the requirementType variable
+                if (!string.IsNullOrEmpty(rawRequirementType) && !Enum.TryParse(rawRequirementType, true, out requirementType))
                 {
-                    if (!Enum.TryParse(rawRequirementType, true, out requirementType))
-                    {
-                        throw new FeatureManagementException(FeatureManagementError.InvalidConfiguration, $"Invalid requirement type '{rawRequirementType}' for feature '{configurationSection.Key}'.");
-                    }
+                    throw new FeatureManagementException(
+                        FeatureManagementError.InvalidValue, 
+                        $"Invalid requirement type '{rawRequirementType}' for feature '{configurationSection.Key}'.");
                 }
 
                 IEnumerable<IConfigurationSection> filterSections = configurationSection.GetSection(FeatureFiltersSectionName).GetChildren();

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -163,7 +163,7 @@ namespace Microsoft.FeatureManagement
                 if (!string.IsNullOrEmpty(rawRequirementType) && !Enum.TryParse(rawRequirementType, true, out requirementType))
                 {
                     throw new FeatureManagementException(
-                        FeatureManagementError.InvalidValue, 
+                        FeatureManagementError.InvalidConfigurationSetting, 
                         $"Invalid requirement type '{rawRequirementType}' for feature '{configurationSection.Key}'.");
                 }
 

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -160,7 +160,7 @@ namespace Microsoft.FeatureManagement
 
                 //
                 // If requirement type is specified, parse it and set the requirementType variable
-                if (!string.IsNullOrEmpty(rawRequirementType) && !Enum.TryParse(rawRequirementType, true, out requirementType))
+                if (!string.IsNullOrEmpty(rawRequirementType) && !Enum.TryParse(rawRequirementType, ignoreCase: true, out requirementType))
                 {
                     throw new FeatureManagementException(
                         FeatureManagementError.InvalidConfigurationSetting, 

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -18,6 +18,7 @@ namespace Microsoft.FeatureManagement
     sealed class ConfigurationFeatureDefinitionProvider : IFeatureDefinitionProvider, IDisposable
     {
         private const string FeatureFiltersSectionName = "EnabledFor";
+        private const string RequirementTypeKeyword = "RequirementType";
         private readonly IConfiguration _configuration;
         private readonly ConcurrentDictionary<string, FeatureDefinition> _definitions;
         private IDisposable _changeSubscription;
@@ -121,9 +122,15 @@ namespace Microsoft.FeatureManagement
             },
             myAlwaysDisabledFeature2: {
               enabledFor: false
-            }
+            },
+            myAllRequiredFilterFeature: {
+                requirementType: "all"
+                enabledFor: [ "myFeatureFilter1", "myFeatureFilter2" ],
+            },
 
             */
+
+            RequirementType requirementType = RequirementType.Any;
 
             var enabledFor = new List<FeatureFilterConfiguration>();
 
@@ -149,6 +156,16 @@ namespace Microsoft.FeatureManagement
             }
             else
             {
+                string rawRequirementType = configurationSection[RequirementTypeKeyword];
+
+                if (!string.IsNullOrEmpty(rawRequirementType))
+                {
+                    if (!Enum.TryParse(rawRequirementType, true, out requirementType))
+                    {
+                        throw new ArgumentException($"Invalid requirement type '{rawRequirementType}' for feature '{configurationSection.Key}'.");
+                    }
+                }
+
                 IEnumerable<IConfigurationSection> filterSections = configurationSection.GetSection(FeatureFiltersSectionName).GetChildren();
 
                 foreach (IConfigurationSection section in filterSections)
@@ -170,7 +187,8 @@ namespace Microsoft.FeatureManagement
             return new FeatureDefinition()
             {
                 Name = configurationSection.Key,
-                EnabledFor = enabledFor
+                EnabledFor = enabledFor,
+                RequirementType = requirementType
             };
         }
 

--- a/src/Microsoft.FeatureManagement/FeatureDefinition.cs
+++ b/src/Microsoft.FeatureManagement/FeatureDefinition.cs
@@ -19,5 +19,11 @@ namespace Microsoft.FeatureManagement
         /// The feature filters that the feature can be enabled for.
         /// </summary>
         public IEnumerable<FeatureFilterConfiguration> EnabledFor { get; set; } = new List<FeatureFilterConfiguration>();
+
+        /// <summary>
+        /// Determines whether any or all registered feature filters must be enabled for the feature to be considered enabled
+        /// The default value is <see cref="RequirementType.Any"/>.
+        /// </summary>
+        public RequirementType RequirementType { get; set; } = RequirementType.Any;
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -24,7 +24,7 @@ namespace Microsoft.FeatureManagement
         MissingFeature,
 
         /// <summary>
-        /// A configuration had conflicting values.
+        /// There was a conflict in the feature management system.
         /// </summary>
         Conflict,
 

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -9,18 +9,23 @@ namespace Microsoft.FeatureManagement
     public enum FeatureManagementError
     {
         /// <summary>
-        /// A feature filter that was listed for feature evaluation was not found.
-        /// </summary>
-        MissingFeatureFilter,
-
-        /// <summary>
         /// A feature filter configured for the feature being evaluated is an ambiguous reference to multiple registered feature filters.
         /// </summary>
         AmbiguousFeatureFilter,
 
         /// <summary>
+        /// A configuration error is present in the feature management system.
+        /// </summary>
+        InvalidConfiguration,
+
+        /// <summary>
         /// A feature that was requested for evaluation was not found.
         /// </summary>
-        MissingFeature
+        MissingFeature,
+
+        /// <summary>
+        /// A feature filter that was listed for feature evaluation was not found.
+        /// </summary>
+        MissingFeatureFilter
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -9,14 +9,14 @@ namespace Microsoft.FeatureManagement
     public enum FeatureManagementError
     {
         /// <summary>
+        /// A feature filter that was listed for feature evaluation was not found.
+        /// </summary>
+        MissingFeatureFilter,
+
+        /// <summary>
         /// A feature filter configured for the feature being evaluated is an ambiguous reference to multiple registered feature filters.
         /// </summary>
         AmbiguousFeatureFilter,
-
-        /// <summary>
-        /// A configuration error is present in the feature management system.
-        /// </summary>
-        InvalidConfiguration,
 
         /// <summary>
         /// A feature that was requested for evaluation was not found.
@@ -24,8 +24,13 @@ namespace Microsoft.FeatureManagement
         MissingFeature,
 
         /// <summary>
-        /// A feature filter that was listed for feature evaluation was not found.
+        /// A configuration had conflicting values.
         /// </summary>
-        MissingFeatureFilter
+        Conflict,
+
+        /// <summary>
+        /// The given value was invalid.
+        /// </summary>
+        InvalidValue
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -29,8 +29,8 @@ namespace Microsoft.FeatureManagement
         Conflict,
 
         /// <summary>
-        /// The given value was invalid.
+        /// The given configuration setting was invalid.
         /// </summary>
-        InvalidValue
+        InvalidConfigurationSetting
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// Controls the behavior of feature evaluation when dependent feature filters are missing.
         /// If missing feature filters are not ignored an exception will be thrown when attempting to evaluate a feature that depends on a missing feature filter.
+        /// This option will throw an error if used in combination with RequirementType.All as the execution may unintentionally enable a flag.
         /// The default value is false.
         /// </summary>
         public bool IgnoreMissingFeatureFilters { get; set; }

--- a/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// Controls the behavior of feature evaluation when dependent feature filters are missing.
         /// If missing feature filters are not ignored an exception will be thrown when attempting to evaluate a feature that depends on a missing feature filter.
-        /// This option will throw an error if used in combination with RequirementType.All as the execution may unintentionally enable a flag.
+        /// This option is invalid when used in combination with <see cref="RequirementType.All"/>
         /// The default value is false.
         /// </summary>
         public bool IgnoreMissingFeatureFilters { get; set; }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -85,7 +85,7 @@ namespace Microsoft.FeatureManagement
 
                 //
                 // Treat an empty list of enabled filters as a disabled feature
-                if (featureDefinition.EnabledFor == null || featureDefinition.EnabledFor.Count() == 0)
+                if (featureDefinition.EnabledFor == null || !featureDefinition.EnabledFor.Any())
                 {
                     enabled = false;
                 }
@@ -150,7 +150,7 @@ namespace Microsoft.FeatureManagement
                                 enabled = targetEvaluation;
 
                                 break;
-                            };
+                            }
                         }
 
                         //
@@ -163,7 +163,6 @@ namespace Microsoft.FeatureManagement
                             break;
                         }
                     }
-
                 }
             }
             else

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -78,8 +78,9 @@ namespace Microsoft.FeatureManagement
             {
                 if (featureDefinition.RequirementType == RequirementType.All && _options.IgnoreMissingFeatureFilters)
                 {
-                    string errorMessage = $"The 'IgnoreMissingFeatureFilters' flag cannot use used in combination with a feature of requirement type 'All'.";
-                    throw new FeatureManagementException(FeatureManagementError.MissingFeatureFilter, errorMessage);
+                    throw new FeatureManagementException(
+                        FeatureManagementError.Conflict, 
+                        $"The 'IgnoreMissingFeatureFilters' flag cannot use used in combination with a feature of requirement type 'All'.");
                 }
 
                 //
@@ -125,10 +126,8 @@ namespace Microsoft.FeatureManagement
                             {
                                 throw new FeatureManagementException(FeatureManagementError.MissingFeatureFilter, errorMessage);
                             }
-                            else
-                            {
-                                _logger.LogWarning(errorMessage);
-                            }
+
+                            _logger.LogWarning(errorMessage);
 
                             continue;
                         }
@@ -162,7 +161,7 @@ namespace Microsoft.FeatureManagement
                             enabled = targetEvaluation;
 
                             break;
-                        };
+                        }
                     }
 
                 }
@@ -177,10 +176,8 @@ namespace Microsoft.FeatureManagement
                 {
                     throw new FeatureManagementException(FeatureManagementError.MissingFeature, errorMessage);
                 }
-                else
-                {
-                    _logger.LogWarning(errorMessage);
-                }
+                
+                _logger.LogWarning(errorMessage);
             }
 
             foreach (ISessionManager sessionManager in _sessionManagers)

--- a/src/Microsoft.FeatureManagement/RequirementType.cs
+++ b/src/Microsoft.FeatureManagement/RequirementType.cs
@@ -4,16 +4,16 @@
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// Describes whether any or all features in a given set should be required to be considered enabled.
+    /// Describes whether any or all conditions in a set should be required to be true.
     /// </summary>
     public enum RequirementType
     {
         /// <summary>
-        /// The enabled state will be attained if any feature in the set is enabled.
+        /// The set of conditions will be evaluated as true if any condition in the set is true.
         /// </summary>
         Any,
         /// <summary>
-        /// The enabled state will be attained if all features in the set are enabled.
+        /// The set of conditions will be evaluated as true if all the conditions in the set are true.
         /// </summary>
         All
     }

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -823,6 +823,37 @@ namespace Tests.FeatureManagement
             Assert.False(await featureManager.IsEnabledAsync(allFilterFeature));
         }
 
+        [Fact]
+        public async Task RequirementTypeAllExceptions()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            string filterOneId = "1";
+
+            var services = new ServiceCollection();
+
+            services
+                .Configure<FeatureManagementOptions>(options =>
+                {
+                    options.IgnoreMissingFeatureFilters = true;
+                });
+
+            services
+                .AddSingleton(config)
+                .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            string allFilterFeature = Enum.GetName(typeof(Features), Features.AllFilterFeature);
+
+            await Assert.ThrowsAsync<FeatureManagementException>(async () =>
+            {
+                await featureManager.IsEnabledAsync(allFilterFeature);
+            });
+        }
+
         private static void DisableEndpointRouting(MvcOptions options)
         {
 #if  NET6_0 || NET5_0 || NETCOREAPP3_1

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -772,12 +772,6 @@ namespace Tests.FeatureManagement
             var services = new ServiceCollection();
 
             services
-                .Configure<FeatureManagementOptions>(options =>
-                {
-                    options.IgnoreMissingFeatureFilters = true;
-                });
-
-            services
                 .AddSingleton(config)
                 .AddFeatureManagement()
                 .AddFeatureFilter<TestFilter>();

--- a/tests/Tests.FeatureManagement/Features.cs
+++ b/tests/Tests.FeatureManagement/Features.cs
@@ -10,6 +10,8 @@ namespace Tests.FeatureManagement
         OnTestFeature,
         OffTestFeature,
         ConditionalFeature,
-        ConditionalFeature2
+        ConditionalFeature2,
+        AnyFilterFeature,
+        AllFilterFeature
     }
 }

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -98,6 +98,41 @@
           }
         }
       ]
+    },
+    "AnyFilterFeature": {
+      "RequirementType": "Any",
+      "EnabledFor": [
+        {
+          "Name": "Test",
+          "Parameters": {
+            "Id": "1"
+          }
+        },
+        {
+          "Name": "Test",
+          "Parameters": {
+            "Id": "2"
+          }
+        }
+      ]
+    },
+    "AllFilterFeature": {
+      "RequirementType": "all",
+      "EnabledFor": [
+        {
+          "Name": "Test",
+          "Parameters": {
+            "Id": "1"
+          }
+        },
+        {
+          "Name": "Test",
+          "Parameters": {
+            "Id": "2"
+          }
+        }
+      ]
+
     }
   }
 }


### PR DESCRIPTION
In response to issue https://github.com/microsoft/FeatureManagement-Dotnet/issues/28.
And as a rewrite of PR https://github.com/microsoft/FeatureManagement-Dotnet/pull/192.

# Add Requirement Type All and Any to FeatureFlags
 
Filters on Feature Flags have always used "Any" logic. Our execution goes through each filter and when a single one returns "true", we end execution and return true. This PR adds "All" logic. For "All", the execution instead goes through each filter and when a single one returns "false", we end execution, returning false. Otherwise we return true.

In short- this PR: 
* Moves RequirementType from AspNetCore to the main .Net library.
* Defaults all unspecified Feature Flags to use "Any" logic
* Adds "All" logic to Feature Flag evaluation

## Example
```json
"AllFilterFeature": {
  "RequirementType": "All",
  "EnabledFor": [
    {
      "Name": "Targeting",
      "Parameters": {
        "Audience": {
          "Users": [
            "Jeff",
            "Alicia"
          ]
        }
      }
    },
    {
      "Name": "TimeWindow",
      "Parameters": {
        "Start": "Wed, 1 April 2023 00:00:00 GMT",
        "End": "Wed, 30 April 2023 23:59:59 GMT"
      }
    }
  ]
```

## Evaluation
```csharp
// Called before TimeWindow:
.IsEnabledAsync(AllFilterFeature, new TargetingContext { UserId = "Jeff" }}) // returns false
.IsEnabledAsync(AllFilterFeature, new TargetingContext { UserId = "Anne" }}) // returns false

// Called during TimeWindow:
.IsEnabledAsync(AllFilterFeature, new TargetingContext { UserId = "Jeff" }}) // returns true
.IsEnabledAsync(AllFilterFeature, new TargetingContext { UserId = "Anne" }}) // returns false
```