### PR TITLE
Add additional null checking to ContextualTargetingFilter

### DIFF
--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -78,7 +78,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 //
                 // Check if the user is in the exclusion directly
                 if (targetingContext.UserId != null &&
-                    settings.Audience.Exclusion.Users != null &&
+                    settings.Audience.Exclusion?.Users != null &&
                     settings.Audience.Exclusion.Users.Any(user => targetingContext.UserId.Equals(user, ComparisonType)))
                 {
                     return Task.FromResult(false);
@@ -87,7 +87,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 //
                 // Check if the user is in a group within exclusion
                 if (targetingContext.Groups != null &&
-                    settings.Audience.Exclusion.Groups != null &&
+                    settings.Audience.Exclusion?.Groups != null &&
                     settings.Audience.Exclusion.Groups.Any(group => targetingContext.Groups.Contains(group, ComparerType)))
                 {
                     return Task.FromResult(false);


### PR DESCRIPTION
Draft fix for issue #244.
This PR needs additional tests to verify this actually fixes the issue mentioned.
Not sure if the `?.` is desired to be used, as the if statement itself is very explicit in null checking.