### PR TITLE
Adds edge case for EvaluateAsync call that doesn't use context from FeatureManager

### DIFF
--- a/src/Microsoft.FeatureManagement.AspNetCore/Microsoft.FeatureManagement.AspNetCore.csproj
+++ b/src/Microsoft.FeatureManagement.AspNetCore/Microsoft.FeatureManagement.AspNetCore.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>6</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Versioning.props" />

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -43,7 +43,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns>True if the feature is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
         {
-            PercentageFilterSettings settings = (PercentageFilterSettings)context.Settings;
+            //
+            // Assume settings was bound from feature manager, if not, bind from parameters
+            PercentageFilterSettings settings = (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
 
             bool result = true;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -43,7 +43,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns>True if the feature is enabled, false otherwise.</returns>
         public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
         {
-            TimeWindowFilterSettings settings = (TimeWindowFilterSettings)context.Settings;
+            //
+            // Assume settings was bound from feature manager, if not, bind from parameters
+            TimeWindowFilterSettings settings = (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
 
             DateTimeOffset now = DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.FeatureManagement/Microsoft.FeatureManagement.csproj
+++ b/src/Microsoft.FeatureManagement/Microsoft.FeatureManagement.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>6</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <Import Project="..\..\build\Versioning.props" />

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -66,7 +66,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 throw new ArgumentNullException(nameof(targetingContext));
             }
 
-            TargetingFilterSettings settings = (TargetingFilterSettings)context.Settings;
+            //
+            // Assume settings was bound from feature manager, if not, bind from parameters
+            TargetingFilterSettings settings = (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
 
             if (!TryValidateSettings(settings, out string paramName, out string message))
             {

--- a/tests/Tests.FeatureManagement/CustomFilterTargeting.cs
+++ b/tests/Tests.FeatureManagement/CustomFilterTargeting.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.FeatureFilters;
+using System;
+using System.Threading.Tasks;
+
+namespace Tests.FeatureManagement
+{
+    class CustomFilterTargeting : IFeatureFilter
+    {
+        private const string Alias = "CustomFilterTargeting";
+        private readonly ContextualTargetingFilter _contextualFilter;
+
+        public CustomFilterTargeting(IOptions<TargetingEvaluationOptions> options, ILoggerFactory loggerFactory)
+        {
+            _contextualFilter = new ContextualTargetingFilter(options, loggerFactory);
+        }
+
+        public Func<FeatureFilterEvaluationContext, Task<bool>> Callback { get; set; }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        {
+            return _contextualFilter.EvaluateAsync(context, new TargetingContext(){ UserId = "Jeff" });
+        }
+    }
+}

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -171,7 +171,29 @@ namespace Tests.FeatureManagement
             Assert.Equal(HttpStatusCode.NotFound, gateAllResponse.StatusCode);
             Assert.Equal(HttpStatusCode.NotFound, gateAnyResponse.StatusCode);
         }
-        
+
+        [Fact]
+        public async Task ContextualTargetingWithNullContext()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            ServiceCollection services = new ServiceCollection();
+            
+            var targetingContextAccessor = new OnDemandTargetingContextAccessor();
+            services.AddSingleton<ITargetingContextAccessor>(targetingContextAccessor);
+
+            services
+                .AddSingleton(config)
+                .AddFeatureManagement()
+                .AddFeatureFilter<CustomFilterTargeting>();
+
+            ServiceProvider provider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = provider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync("CustomFilterFeature"));
+        }
+
         [Fact]
         public async Task GatesRazorPageFeatures()
         {

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -70,6 +70,20 @@
         }
       ]
     },
+    "CustomFilterFeature": {
+      "EnabledFor": [
+        {
+          "Name": "CustomFilterTargeting",
+          "Parameters": {
+            "Audience": {
+              "Users": [
+                "Jeff"
+              ]
+            }
+          }
+        }
+      ]
+    },
     "ConditionalFeature": {
       "EnabledFor": [
         {


### PR DESCRIPTION
Handles edge case from https://github.com/microsoft/FeatureManagement-Dotnet/issues/244

The parameters to settings binding happens in the FeatureManager before calling each individual filter. This lead to the assumption that all filters would have the settings object available. 

In this case, the filter is called with context that was not binded by FeatureManager. This meant settings could be null.

This fix adds a check for that situation and binds if needed. When hitting this scenario, the app doesn't benefit from the caching changes described in https://github.com/microsoft/FeatureManagement-Dotnet/releases/tag/2.6.0-preview2