### PR TITLE
Add edge case for exact 100 bucket

### DIFF
--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -142,6 +142,13 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns>A boolean representing if the context identifier should be targeted</returns>
         private bool IsTargeted(string contextId, double percentage)
         {
+            //
+            // Handle edge case of exact 100 bucket
+            if (percentage == 100)
+            {
+                return true;
+            }
+
             byte[] hash;
 
             using (HashAlgorithm hashAlgorithm = SHA256.Create())


### PR DESCRIPTION
Adds an edge case for the `1 / MaxInt` chance that a person is placed in exactly at 100%, which currently isn't handled by the existing `<`. Using `<=` would cause other percents to fall in multiple buckets, so the edge case only applies to 100, where there is no higher bucket.