### PR TITLE
Allow different type of filters to share the same Alias

### DIFF
--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -53,6 +53,11 @@ namespace Microsoft.FeatureManagement
             return _evaluateFunc(_filter, evaluationContext, context);
         }
 
+        public static bool IsContextualFilter(IFeatureFilterMetadata filter, Type appContextType)
+        {
+            return GetContextualFilterInterface(filter, appContextType) != null;
+        }
+
         private static Type GetContextualFilterInterface(IFeatureFilterMetadata filter, Type appContextType)
         {
             IEnumerable<Type> contextualFilterInterfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));

--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -53,11 +53,6 @@ namespace Microsoft.FeatureManagement
             return _evaluateFunc(_filter, evaluationContext, context);
         }
 
-        public static bool IsContextualFilter(IFeatureFilterMetadata filter, Type appContextType)
-        {
-            return GetContextualFilterInterface(filter, appContextType) != null;
-        }
-
         private static Type GetContextualFilterInterface(IFeatureFilterMetadata filter, Type appContextType)
         {
             IEnumerable<Type> contextualFilterInterfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -357,7 +357,7 @@ namespace Microsoft.FeatureManagement
             }
 
             ContextualFeatureFilterEvaluator filter = _contextualFeatureFilterCache.GetOrAdd(
-                $"{filterName}{Environment.NewLine}{appContextType?.FullName}",
+                $"{filterName}{Environment.NewLine}{appContextType.FullName}",
                 (_) => {
 
                     IFeatureFilterMetadata metadata = GetFeatureFilterMetadata(filterName, appContextType);

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -175,7 +175,7 @@ namespace Microsoft.FeatureManagement
 
                         //
                         // IContextualFeatureFilter
-                        if (useAppContext && !(filter is IFeatureFilter))
+                        if (useAppContext && ContextualFeatureFilterEvaluator.IsContextualFilter(filter, typeof(TContext)))
                         {
                             ContextualFeatureFilterEvaluator contextualFilter = GetContextualFeatureFilter(featureFilterConfiguration.Name, typeof(TContext));
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -143,14 +143,14 @@ namespace Microsoft.FeatureManagement
 
                         IFeatureFilterMetadata filter;
 
-                        if (appContext == null)
+                        if (useAppContext)
                         {
-                            filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, null);
+                            filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, typeof(TContext)) ??
+                                     GetFeatureFilterMetadata(featureFilterConfiguration.Name, null);
                         }
                         else
                         {
-                            filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, appContext.GetType()) ??
-                                     GetFeatureFilterMetadata(featureFilterConfiguration.Name, null);
+                            filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, null);
                         }
 
                         if (filter == null)

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -141,13 +141,21 @@ namespace Microsoft.FeatureManagement
                             continue;
                         }
 
-                        IFeatureFilterMetadata filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, appContext?.GetType());
+                        IFeatureFilterMetadata filter;
+
+                        if (appContext == null)
+                        {
+                            filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, null);
+                        }
+                        else
+                        {
+                            filter = GetFeatureFilterMetadata(featureFilterConfiguration.Name, appContext.GetType()) ??
+                                     GetFeatureFilterMetadata(featureFilterConfiguration.Name, null);
+                        }
 
                         if (filter == null)
                         {
-                            string errorMessage = appContext == null
-                                                ? $"The feature filter '{featureFilterConfiguration.Name}' specified for feature '{featureDefinition.Name}' was not found."
-                                                : $"The contextual feature filter '{featureFilterConfiguration.Name}' with context type '{appContext.GetType()}', specified for feature '{featureDefinition.Name}' was not found.";
+                            string errorMessage = $"The feature filter '{featureFilterConfiguration.Name}' specified for feature '{feature}' was not found.";
 
                             if (!_options.IgnoreMissingFeatureFilters)
                             {
@@ -167,7 +175,7 @@ namespace Microsoft.FeatureManagement
 
                         //
                         // IContextualFeatureFilter
-                        if (useAppContext)
+                        if (useAppContext && !(filter is IFeatureFilter))
                         {
                             ContextualFeatureFilterEvaluator contextualFilter = GetContextualFeatureFilter(featureFilterConfiguration.Name, typeof(TContext));
 

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -149,7 +149,7 @@ namespace Tests.FeatureManagement
 
             featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            FeatureManagementException ex = await Assert.ThrowsAsync<FeatureManagementException>(
+            var ex = await Assert.ThrowsAsync<FeatureManagementException>(
                 async () =>
                 {
                     await featureManager.IsEnabledAsync(featureName);

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -99,7 +99,8 @@ namespace Tests.FeatureManagement
                 .AddFeatureManagement()
                 .AddFeatureFilter<DuplicatedAliasFeatureFilter1>()
                 .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithAccountContext>()
-                .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithDummyContext1>();
+                .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithDummyContext1>()
+                .AddFeatureFilter<PercentageFilter>();
 
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
@@ -121,7 +122,22 @@ namespace Tests.FeatureManagement
                 .AddSingleton(config)
                 .AddFeatureManagement()
                 .AddFeatureFilter<DuplicatedAliasFeatureFilter1>()
-                .AddFeatureFilter<DuplicatedAliasFeatureFilter2>();
+                .AddFeatureFilter<PercentageFilter>();
+
+            serviceProvider = services.BuildServiceProvider();
+
+            featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias), dummyContext));
+
+            services = new ServiceCollection();
+
+            services
+                .AddSingleton(config)
+                .AddFeatureManagement()
+                .AddFeatureFilter<DuplicatedAliasFeatureFilter1>()
+                .AddFeatureFilter<DuplicatedAliasFeatureFilter2>()
+                .AddFeatureFilter<PercentageFilter>();
 
             serviceProvider = services.BuildServiceProvider();
 
@@ -141,7 +157,8 @@ namespace Tests.FeatureManagement
                 .AddSingleton(config)
                 .AddFeatureManagement()
                 .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithDummyContext1>()
-                .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithDummyContext2>();
+                .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithDummyContext2>()
+                .AddFeatureFilter<PercentageFilter>();
 
             serviceProvider = services.BuildServiceProvider();
 
@@ -160,7 +177,8 @@ namespace Tests.FeatureManagement
             services
                 .AddSingleton(config)
                 .AddFeatureManagement()
-                .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithDummyContext1>();
+                .AddFeatureFilter<ContextualDuplicatedAliasFeatureFilterWithAccountContext>()
+                .AddFeatureFilter<PercentageFilter>();
 
             serviceProvider = services.BuildServiceProvider();
 
@@ -173,25 +191,6 @@ namespace Tests.FeatureManagement
                 });
 
             Assert.Equal($"The feature filter '{duplicatedFilterName}' specified for feature '{Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias)}' was not found.", ex.Message);
-
-            services = new ServiceCollection();
-
-            services
-                .AddSingleton(config)
-                .AddFeatureManagement()
-                .AddFeatureFilter<DuplicatedAliasFeatureFilter1>();
-
-            serviceProvider = services.BuildServiceProvider();
-
-            featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
-
-            ex = await Assert.ThrowsAsync<FeatureManagementException>(
-                async () =>
-                {
-                    await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias), dummyContext);
-                });
-
-            Assert.Equal($"The contextual feature filter '{duplicatedFilterName}' with context type '{dummyContext.GetType()}', specified for feature '{Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias)}' was not found.", ex.Message);
         }
 
         [Fact]
@@ -284,7 +283,7 @@ namespace Tests.FeatureManagement
                 }
             }
 
-            Assert.True(enabledCount > 0 && enabledCount < 10);
+            Assert.True(enabledCount >= 0 && enabledCount < 10);
         }
 
         [Fact]

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -90,6 +90,8 @@ namespace Tests.FeatureManagement
         {
             const string duplicatedFilterName = "DuplicatedFilterName";
 
+            string featureName = Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias);
+
             IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
 
             var services = new ServiceCollection();
@@ -110,11 +112,11 @@ namespace Tests.FeatureManagement
 
             DummyContext dummyContext = new DummyContext();
 
-            Assert.True(await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias)));
+            Assert.True(await featureManager.IsEnabledAsync(featureName));
 
-            Assert.True(await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias), appContext));
+            Assert.True(await featureManager.IsEnabledAsync(featureName, appContext));
 
-            Assert.True(await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias), dummyContext));
+            Assert.True(await featureManager.IsEnabledAsync(featureName, dummyContext));
 
             services = new ServiceCollection();
 
@@ -128,7 +130,7 @@ namespace Tests.FeatureManagement
 
             featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            Assert.True(await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias), dummyContext));
+            Assert.True(await featureManager.IsEnabledAsync(featureName, dummyContext));
 
             services = new ServiceCollection();
 
@@ -146,7 +148,7 @@ namespace Tests.FeatureManagement
             FeatureManagementException ex = await Assert.ThrowsAsync<FeatureManagementException>(
                 async () =>
                 {
-                    await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias));
+                    await featureManager.IsEnabledAsync(featureName);
                 });
 
             Assert.Equal($"Multiple feature filters match the configured filter named '{duplicatedFilterName}'.", ex.Message);
@@ -167,10 +169,10 @@ namespace Tests.FeatureManagement
             ex = await Assert.ThrowsAsync<FeatureManagementException>(
                 async () =>
                 {
-                    await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias), dummyContext);
+                    await featureManager.IsEnabledAsync(featureName, dummyContext);
                 });
 
-            Assert.Equal($"Multiple contextual feature filters match the configured filter named '{duplicatedFilterName}' and context type '{dummyContext.GetType()}'.", ex.Message);
+            Assert.Equal($"Multiple contextual feature filters match the configured filter named '{duplicatedFilterName}' and context type '{typeof(DummyContext)}'.", ex.Message);
 
             services = new ServiceCollection();
 
@@ -187,10 +189,10 @@ namespace Tests.FeatureManagement
             ex = await Assert.ThrowsAsync<FeatureManagementException>(
                 async () =>
                 {
-                    await featureManager.IsEnabledAsync(Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias));
+                    await featureManager.IsEnabledAsync(featureName);
                 });
 
-            Assert.Equal($"The feature filter '{duplicatedFilterName}' specified for feature '{Enum.GetName(typeof(Features), Features.FeatureUsesFiltersWithDuplicatedAlias)}' was not found.", ex.Message);
+            Assert.Equal($"The feature filter '{duplicatedFilterName}' specified for feature '{featureName}' was not found.", ex.Message);
         }
 
         [Fact]

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -108,15 +108,19 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            AppContext appContext = new AppContext();
+            var appContext = new AppContext();
 
-            DummyContext dummyContext = new DummyContext();
+            var dummyContext = new DummyContext();
+            
+            var targetingContext = new TargetingContext();
 
             Assert.True(await featureManager.IsEnabledAsync(featureName));
 
             Assert.True(await featureManager.IsEnabledAsync(featureName, appContext));
 
             Assert.True(await featureManager.IsEnabledAsync(featureName, dummyContext));
+
+            Assert.True(await featureManager.IsEnabledAsync(featureName, targetingContext));
 
             services = new ServiceCollection();
 

--- a/tests/Tests.FeatureManagement/Features.cs
+++ b/tests/Tests.FeatureManagement/Features.cs
@@ -13,6 +13,7 @@ namespace Tests.FeatureManagement
         ConditionalFeature2,
         ContextualFeature,
         AnyFilterFeature,
-        AllFilterFeature
+        AllFilterFeature,
+        FeatureUsesFiltersWithDuplicatedAlias
     }
 }

--- a/tests/Tests.FeatureManagement/FiltersWithDuplicatedAlias.cs
+++ b/tests/Tests.FeatureManagement/FiltersWithDuplicatedAlias.cs
@@ -8,7 +8,7 @@ namespace Tests.FeatureManagement
 {
     interface IDummyContext
     {
-        string DummyProperty { get; }
+        string DummyProperty { get; set; }
     }
 
     class DummyContext : IDummyContext

--- a/tests/Tests.FeatureManagement/FiltersWithDuplicatedAlias.cs
+++ b/tests/Tests.FeatureManagement/FiltersWithDuplicatedAlias.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+using System.Threading.Tasks;
+
+namespace Tests.FeatureManagement
+{
+    interface IDummyContext
+    {
+        string DummyProperty { get; }
+    }
+
+    class DummyContext : IDummyContext
+    {
+        public string DummyProperty { get; set; }
+    }
+
+    [FilterAlias(Alias)]
+    class DuplicatedAliasFeatureFilter1 : IFeatureFilter
+    {
+        private const string Alias = "DuplicatedFilterName";
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    [FilterAlias(Alias)]
+    class DuplicatedAliasFeatureFilter2 : IFeatureFilter
+    {
+        private const string Alias = "DuplicatedFilterName";
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    [FilterAlias(Alias)]
+    class ContextualDuplicatedAliasFeatureFilterWithAccountContext : IContextualFeatureFilter<IAccountContext>
+    {
+        private const string Alias = "DuplicatedFilterName";
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    [FilterAlias(Alias)]
+    class ContextualDuplicatedAliasFeatureFilterWithDummyContext1 : IContextualFeatureFilter<IDummyContext>
+    {
+        private const string Alias = "DuplicatedFilterName";
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IDummyContext dummyContext)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    [FilterAlias(Alias)]
+    class ContextualDuplicatedAliasFeatureFilterWithDummyContext2 : IContextualFeatureFilter<IDummyContext>
+    {
+        private const string Alias = "DuplicatedFilterName";
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IDummyContext dummyContext)
+        {
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -10,9 +10,16 @@
     "OnTestFeature": true,
     "OffTestFeature": false,
     "FeatureUsesFiltersWithDuplicatedAlias": {
+      "RequirementType": "all",
       "EnabledFor": [
         {
           "Name": "DuplicatedFilterName"
+        },
+        {
+          "Name": "Percentage",
+          "Parameters": {
+            "Value":  100
+          }
         }
       ]
     },

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -9,6 +9,13 @@
   "FeatureManagement": {
     "OnTestFeature": true,
     "OffTestFeature": false,
+    "FeatureUsesFiltersWithDuplicatedAlias": {
+      "EnabledFor": [
+        {
+          "Name": "DuplicatedFilterName"
+        }
+      ]
+    },
     "TargetingTestFeature": {
       "EnabledFor": [
         {


### PR DESCRIPTION
Allow filters to share the same Alias. This PR will resolve #98.
One FeatureFilter and multiple ContextualFeatureFilters using different types of context can share the same Alias.

We plan to register built-in filter including percentage, time window and contextual targeting filters by default when AddFeatureManagement() is called.
However, the contextual targeting and targeting filter share the same alias "Microsoft.Targeting". Currently, feature management does not allow filters share the same alias. This PR will also un-block this.