### PR TITLE
Rename UseTopLevelConfiguration

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// The option that controls the behavior when "FeatureManagement" section in the configuration is missing.
         /// </summary>
-        public bool TopLevelConfigurationEnabled { get; init; }
+        public bool RootConfigurationFallBackEnabled { get; init; }
 
         public void Dispose()
         {
@@ -224,7 +224,7 @@ namespace Microsoft.FeatureManagement
 
             //
             // There is no "FeatureManagement" section in the configuration
-            if (TopLevelConfigurationEnabled)
+            if (RootConfigurationFallBackEnabled)
             {
                 return _configuration.GetChildren();
             }

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// The option that controls the behavior when "FeatureManagement" section in the configuration is missing.
         /// </summary>
-        public bool RootConfigurationFallBackEnabled { get; init; }
+        public bool RootConfigurationFallbackEnabled { get; init; }
 
         public void Dispose()
         {
@@ -224,7 +224,7 @@ namespace Microsoft.FeatureManagement
 
             //
             // There is no "FeatureManagement" section in the configuration
-            if (RootConfigurationFallBackEnabled)
+            if (RootConfigurationFallbackEnabled)
             {
                 return _configuration.GetChildren();
             }

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// The option that controls the behavior when "FeatureManagement" section in the configuration is missing.
         /// </summary>
-        public bool UseTopLevelConfiguration { get; init; }
+        public bool TopLevelConfigurationEnabled { get; init; }
 
         public void Dispose()
         {
@@ -224,7 +224,7 @@ namespace Microsoft.FeatureManagement
 
             //
             // There is no "FeatureManagement" section in the configuration
-            if (UseTopLevelConfiguration)
+            if (TopLevelConfigurationEnabled)
             {
                 return _configuration.GetChildren();
             }

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.FeatureManagement
                     configuration,
                     sp.GetRequiredService<ILoggerFactory>())
                 {
-                    UseTopLevelConfiguration = true
+                    TopLevelConfigurationEnabled = true
                 });
 
             return services.AddFeatureManagement();
@@ -159,7 +159,7 @@ namespace Microsoft.FeatureManagement
                     configuration,
                     sp.GetRequiredService<ILoggerFactory>())
                 {
-                    UseTopLevelConfiguration = true
+                    TopLevelConfigurationEnabled = true
                 });
 
             return services.AddScopedFeatureManagement();

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.FeatureManagement
                     configuration,
                     sp.GetRequiredService<ILoggerFactory>())
                 {
-                    TopLevelConfigurationEnabled = true
+                    RootConfigurationFallBackEnabled = true
                 });
 
             return services.AddFeatureManagement();
@@ -159,7 +159,7 @@ namespace Microsoft.FeatureManagement
                     configuration,
                     sp.GetRequiredService<ILoggerFactory>())
                 {
-                    TopLevelConfigurationEnabled = true
+                    RootConfigurationFallBackEnabled = true
                 });
 
             return services.AddScopedFeatureManagement();

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.FeatureManagement
                     configuration,
                     sp.GetRequiredService<ILoggerFactory>())
                 {
-                    RootConfigurationFallBackEnabled = true
+                    RootConfigurationFallbackEnabled = true
                 });
 
             return services.AddFeatureManagement();
@@ -159,7 +159,7 @@ namespace Microsoft.FeatureManagement
                     configuration,
                     sp.GetRequiredService<ILoggerFactory>())
                 {
-                    RootConfigurationFallBackEnabled = true
+                    RootConfigurationFallbackEnabled = true
                 });
 
             return services.AddScopedFeatureManagement();

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -257,8 +257,6 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            var appContext = new AppContext();
-
             var dummyContext = new DummyContext();
 
             Assert.True(await featureManager.IsEnabledAsync(featureName));


### PR DESCRIPTION
Adhere to .net property naming [guidelines ](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-type-members#names-of-properties)

Rename the property to adjective.