### PR TITLE
Expose ConfigurationFeatureDefinitionProvider to public

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.FeatureManagement
     /// <summary>
     /// A feature definition provider that pulls feature definitions from the .NET Core <see cref="IConfiguration"/> system.
     /// </summary>
-    sealed class ConfigurationFeatureDefinitionProvider : IFeatureDefinitionProvider, IDisposable, IFeatureDefinitionProviderCacheable
+    public sealed class ConfigurationFeatureDefinitionProvider : IFeatureDefinitionProvider, IDisposable, IFeatureDefinitionProviderCacheable
     {
         //
         // IFeatureDefinitionProviderCacheable interface is only used to mark this provider as cacheable. This allows our test suite's
@@ -27,14 +27,16 @@ namespace Microsoft.FeatureManagement
         private const string FeatureManagementSectionName = "FeatureManagement";
         private readonly IConfiguration _configuration;
         private readonly ConcurrentDictionary<string, FeatureDefinition> _definitions;
-        private readonly ILogger _logger;
         private IDisposable _changeSubscription;
         private int _stale = 0;
 
-        public ConfigurationFeatureDefinitionProvider(IConfiguration configuration, ILoggerFactory loggerFactory)
+        /// <summary>
+        /// Creates a configuration feature definition provider.
+        /// </summary>
+        /// <param name="configuration">The configuration of feature definitions.</param>
+        public ConfigurationFeatureDefinitionProvider(IConfiguration configuration)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _logger = loggerFactory?.CreateLogger<ConfigurationFeatureDefinitionProvider>() ?? throw new ArgumentNullException(nameof(loggerFactory));
             _definitions = new ConcurrentDictionary<string, FeatureDefinition>();
 
             _changeSubscription = ChangeToken.OnChange(
@@ -47,6 +49,14 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         public bool UseTopLevelConfiguration { get; init; }
 
+        /// <summary>
+        /// The logger for the configuration feature definition provider.
+        /// </summary>
+        public ILogger Logger { get; init; }
+
+        /// <summary>
+        /// Disposes the change subscription of the configuration.
+        /// </summary>
         public void Dispose()
         {
             _changeSubscription?.Dispose();
@@ -54,6 +64,11 @@ namespace Microsoft.FeatureManagement
             _changeSubscription = null;
         }
 
+        /// <summary>
+        /// Retrieves the definition for a given feature.
+        /// </summary>
+        /// <param name="featureName">The name of the feature to retrieve the definition for.</param>
+        /// <returns>The feature's definition.</returns>
         public Task<FeatureDefinition> GetFeatureDefinitionAsync(string featureName)
         {
             if (featureName == null)
@@ -78,6 +93,10 @@ namespace Microsoft.FeatureManagement
             return Task.FromResult(definition);
         }
 
+        /// <summary>
+        /// Retrieves definitions for all features.
+        /// </summary>
+        /// <returns>An enumerator which provides asynchronous iteration over feature definitions.</returns>
         //
         // The async key word is necessary for creating IAsyncEnumerable.
         // The need to disable this warning occurs when implementaing async stream synchronously. 
@@ -229,7 +248,7 @@ namespace Microsoft.FeatureManagement
                 return _configuration.GetChildren();
             }
 
-            _logger.LogDebug($"No configuration section named '{FeatureManagementSectionName}' was found.");
+            Logger?.LogDebug($"No configuration section named '{FeatureManagementSectionName}' was found.");
 
             return Enumerable.Empty<IConfigurationSection>();
         }

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -82,11 +82,10 @@ namespace Microsoft.FeatureManagement
             }
 
             services.AddSingleton<IFeatureDefinitionProvider>(sp =>
-                new ConfigurationFeatureDefinitionProvider(
-                    configuration,
-                    sp.GetRequiredService<ILoggerFactory>())
+                new ConfigurationFeatureDefinitionProvider(configuration)
                 {
-                    UseTopLevelConfiguration = true
+                    UseTopLevelConfiguration = true,
+                    Logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<ConfigurationFeatureDefinitionProvider>()
                 });
 
             return services.AddFeatureManagement();
@@ -155,11 +154,10 @@ namespace Microsoft.FeatureManagement
             }
 
             services.AddSingleton<IFeatureDefinitionProvider>(sp =>
-                new ConfigurationFeatureDefinitionProvider(
-                    configuration,
-                    sp.GetRequiredService<ILoggerFactory>())
+                new ConfigurationFeatureDefinitionProvider(configuration)
                 {
-                    UseTopLevelConfiguration = true
+                    UseTopLevelConfiguration = true,
+                    Logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<ConfigurationFeatureDefinitionProvider>()
                 });
 
             return services.AddScopedFeatureManagement();


### PR DESCRIPTION
We have exposed FeatureManager to public, which make it possible to use Feature Management in other third-party DI container frameworks.
Currently, when our user wants to use Feature Management in other DI container (e.g. Autofac), they need to implement their own IFeatureDefinitionProvider and register it into DI container because the built-in ConfigurationDefinitionProvider is an internal class.
To provide more convenience for our users, I think it will be very helpful to expose ConfigurationFeatureDefinitionProvider to public so that users can use it directly.