### PR TITLE
Add size for cache entry

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -321,7 +321,7 @@ namespace Microsoft.FeatureManagement
                     {
                         SlidingExpiration = ParametersCacheSlidingExpiration,
                         AbsoluteExpirationRelativeToNow = ParametersCacheAbsoluteExpirationRelativeToNow
-                    });
+                    }.SetSize(1));
             }
             else
             {

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -320,8 +320,9 @@ namespace Microsoft.FeatureManagement
                     new MemoryCacheEntryOptions
                     {
                         SlidingExpiration = ParametersCacheSlidingExpiration,
-                        AbsoluteExpirationRelativeToNow = ParametersCacheAbsoluteExpirationRelativeToNow
-                    }.SetSize(1));
+                        AbsoluteExpirationRelativeToNow = ParametersCacheAbsoluteExpirationRelativeToNow,
+                        Size = 1
+                    });
             }
             else
             {


### PR DESCRIPTION
Try to fix the bug introduced by 3.1.0.
The feature manager uses the shared memory cache and it doesn't specify the entry size. This will cause error if the shared memory cache has a size limit. #325 