### PR TITLE
Adds extension methods for TrackEvent and TrackMetric

### DIFF
--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.ApplicationInsights;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.FeatureManagement.FeatureFilters;
 
@@ -10,7 +13,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
     public static class ApplicationInsightsTelemetryExtensions
     {
         /// <summary>
-        /// Extension method to track an event with TargetingContext.
+        /// Extension method to track an event with <see cref="TargetingContext"/>.
         /// </summary>
         public static void TrackEvent(this TelemetryClient telemetryClient, string eventName, TargetingContext targetingContext, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
         {
@@ -19,13 +22,13 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
                 properties = new Dictionary<string, string>();
             }
 
-            properties.Add("TargetingId", targetingContext.UserId);
+            properties["TargetingId"] = targetingContext.UserId;
 
             telemetryClient.TrackEvent(eventName, properties, metrics);
         }
 
         /// <summary>
-        /// Extension method to track an EventTelemetry with TargetingContext.
+        /// Extension method to track an <see cref="EventTelemetry"/> with <see cref="TargetingContext"/>.
         /// </summary>
         public static void TrackEvent(this TelemetryClient telemetryClient, EventTelemetry telemetry, TargetingContext targetingContext)
         {
@@ -40,7 +43,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
         }
 
         /// <summary>
-        /// Extension method to track a metric with TargetingContext.
+        /// Extension method to track a metric with <see cref="TargetingContext"/>.
         /// </summary>
         public static void TrackMetric(this TelemetryClient telemetryClient, string name, double value, TargetingContext targetingContext, IDictionary<string, string> properties = null)
         {
@@ -49,13 +52,13 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
                 properties = new Dictionary<string, string>();
             }
 
-            properties.Add("TargetingId", targetingContext.UserId);
+            properties["TargetingId"] = targetingContext.UserId;
 
             telemetryClient.TrackMetric(name, value, properties);
         }
 
         /// <summary>
-        /// Extension method to track a MetricTelemetry with TargetingContext.
+        /// Extension method to track a <see cref="MetricTelemetry"/> with <see cref="TargetingContext"/>.
         /// </summary>
         public static void TrackMetric(this TelemetryClient telemetryClient, MetricTelemetry telemetry, TargetingContext targetingContext)
         {

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryExtensions.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.FeatureManagement.FeatureFilters;
+
+namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
+{
+    /// <summary>
+    /// Provides extension methods for tracking events with TargetingContext.
+    /// </summary>
+    public static class ApplicationInsightsTelemetryExtensions
+    {
+        /// <summary>
+        /// Extension method to track an event with TargetingContext.
+        /// </summary>
+        public static void TrackEvent(this TelemetryClient telemetryClient, string eventName, TargetingContext targetingContext, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+        {
+            if (properties == null)
+            {
+                properties = new Dictionary<string, string>();
+            }
+
+            properties.Add("TargetingId", targetingContext.UserId);
+
+            telemetryClient.TrackEvent(eventName, properties, metrics);
+        }
+
+        /// <summary>
+        /// Extension method to track an EventTelemetry with TargetingContext.
+        /// </summary>
+        public static void TrackEvent(this TelemetryClient telemetryClient, EventTelemetry telemetry, TargetingContext targetingContext)
+        {
+            if (telemetry == null)
+            {
+                telemetry = new EventTelemetry();
+            }
+
+            telemetry.Properties["TargetingId"] = targetingContext.UserId;
+
+            telemetryClient.TrackEvent(telemetry);
+        }
+
+        /// <summary>
+        /// Extension method to track a metric with TargetingContext.
+        /// </summary>
+        public static void TrackMetric(this TelemetryClient telemetryClient, string name, double value, TargetingContext targetingContext, IDictionary<string, string> properties = null)
+        {
+            if (properties == null)
+            {
+                properties = new Dictionary<string, string>();
+            }
+
+            properties.Add("TargetingId", targetingContext.UserId);
+
+            telemetryClient.TrackMetric(name, value, properties);
+        }
+
+        /// <summary>
+        /// Extension method to track a MetricTelemetry with TargetingContext.
+        /// </summary>
+        public static void TrackMetric(this TelemetryClient telemetryClient, MetricTelemetry telemetry, TargetingContext targetingContext)
+        {
+            if (telemetry == null)
+            {
+                telemetry = new MetricTelemetry();
+            }
+
+            telemetry.Properties["TargetingId"] = targetingContext.UserId;
+
+            telemetryClient.TrackMetric(telemetry);
+        }
+    }
+}

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
     /// <summary>
     /// Provides extension methods for tracking events with TargetingContext.
     /// </summary>
-    public static class ApplicationInsightsTelemetryExtensions
+    public static class TelemetryClientExtensions
     {
         /// <summary>
         /// Extension method to track an event with <see cref="TargetingContext"/>.

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
                 properties = new Dictionary<string, string>();
             }
 
-            AddTargetingProperties(properties, targetingContext);
+            properties["TargetingId"] = targetingContext.UserId;
 
             telemetryClient.TrackEvent(eventName, properties, metrics);
         }
@@ -41,43 +41,9 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
                 telemetry = new EventTelemetry();
             }
 
-            AddTargetingProperties(telemetry.Properties, targetingContext);
+            telemetry.Properties["TargetingId"] = targetingContext.UserId;
 
             telemetryClient.TrackEvent(telemetry);
-        }
-
-        /// <summary>
-        /// Extension method to track a metric with <see cref="TargetingContext"/>.
-        /// </summary>
-        public static void TrackMetric(this TelemetryClient telemetryClient, string name, double value, TargetingContext targetingContext, IDictionary<string, string> properties = null)
-        {
-            ValidateTargetingContext(targetingContext);
-
-            if (properties == null)
-            {
-                properties = new Dictionary<string, string>();
-            }
-
-            AddTargetingProperties(properties, targetingContext);
-
-            telemetryClient.TrackMetric(name, value, properties);
-        }
-
-        /// <summary>
-        /// Extension method to track a <see cref="MetricTelemetry"/> with <see cref="TargetingContext"/>.
-        /// </summary>
-        public static void TrackMetric(this TelemetryClient telemetryClient, MetricTelemetry telemetry, TargetingContext targetingContext)
-        {
-            ValidateTargetingContext(targetingContext);
-
-            if (telemetry == null)
-            {
-                telemetry = new MetricTelemetry();
-            }
-
-            AddTargetingProperties(telemetry.Properties, targetingContext);
-
-            telemetryClient.TrackMetric(telemetry);
         }
 
         private static void ValidateTargetingContext(TargetingContext targetingContext)
@@ -86,11 +52,6 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
             {
                 throw new ArgumentNullException(nameof(targetingContext));
             }
-        }
-
-        private static void AddTargetingProperties(IDictionary<string, string> properties, TargetingContext targetingContext)
-        {
-            properties["TargetingId"] = targetingContext.UserId;
         }
     }
 }

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
@@ -17,12 +17,14 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
         /// </summary>
         public static void TrackEvent(this TelemetryClient telemetryClient, string eventName, TargetingContext targetingContext, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
         {
+            ValidateTargetingContext(targetingContext);
+
             if (properties == null)
             {
                 properties = new Dictionary<string, string>();
             }
 
-            properties["TargetingId"] = targetingContext.UserId;
+            AddTargetingProperties(properties, targetingContext);
 
             telemetryClient.TrackEvent(eventName, properties, metrics);
         }
@@ -32,12 +34,14 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
         /// </summary>
         public static void TrackEvent(this TelemetryClient telemetryClient, EventTelemetry telemetry, TargetingContext targetingContext)
         {
+            ValidateTargetingContext(targetingContext);
+
             if (telemetry == null)
             {
                 telemetry = new EventTelemetry();
             }
 
-            telemetry.Properties["TargetingId"] = targetingContext.UserId;
+            AddTargetingProperties(telemetry.Properties, targetingContext);
 
             telemetryClient.TrackEvent(telemetry);
         }
@@ -47,12 +51,14 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
         /// </summary>
         public static void TrackMetric(this TelemetryClient telemetryClient, string name, double value, TargetingContext targetingContext, IDictionary<string, string> properties = null)
         {
+            ValidateTargetingContext(targetingContext);
+
             if (properties == null)
             {
                 properties = new Dictionary<string, string>();
             }
 
-            properties["TargetingId"] = targetingContext.UserId;
+            AddTargetingProperties(properties, targetingContext);
 
             telemetryClient.TrackMetric(name, value, properties);
         }
@@ -62,14 +68,29 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
         /// </summary>
         public static void TrackMetric(this TelemetryClient telemetryClient, MetricTelemetry telemetry, TargetingContext targetingContext)
         {
+            ValidateTargetingContext(targetingContext);
+
             if (telemetry == null)
             {
                 telemetry = new MetricTelemetry();
             }
 
-            telemetry.Properties["TargetingId"] = targetingContext.UserId;
+            AddTargetingProperties(telemetry.Properties, targetingContext);
 
             telemetryClient.TrackMetric(telemetry);
+        }
+
+        private static void ValidateTargetingContext(TargetingContext targetingContext)
+        {
+            if (targetingContext == null)
+            {
+                throw new ArgumentNullException(nameof(targetingContext));
+            }
+        }
+
+        private static void AddTargetingProperties(IDictionary<string, string> properties, TargetingContext targetingContext)
+        {
+            properties["TargetingId"] = targetingContext.UserId;
         }
     }
 }


### PR DESCRIPTION
Adds TargetingContext extension method for:
1. TrackEvent
2. TrackMetric

There are other track calls, but those calls are not a part of the happy path. `TargetingId` is only helpful in the happy path. Does not add extensions for:
1. TrackTrace
2. TrackException
3. TrackDependency
4. TrackAvailability