### PR TITLE
Adds targeting middleware and targeting initializer

### DIFF
--- a/Microsoft.FeatureManagement.sln
+++ b/Microsoft.FeatureManagement.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FeatureManagement
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EvaluationDataToApplicationInsights", "examples\EvaluationDataToApplicationInsights\EvaluationDataToApplicationInsights.csproj", "{1502529E-47E9-4306-98C4-BF6CF7C7C275}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore", "src\Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore\Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore.csproj", "{C647611B-A8E5-4AD7-9DBA-60DDE276644B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{1502529E-47E9-4306-98C4-BF6CF7C7C275}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1502529E-47E9-4306-98C4-BF6CF7C7C275}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1502529E-47E9-4306-98C4-BF6CF7C7C275}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C647611B-A8E5-4AD7-9DBA-60DDE276644B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C647611B-A8E5-4AD7-9DBA-60DDE276644B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C647611B-A8E5-4AD7-9DBA-60DDE276644B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C647611B-A8E5-4AD7-9DBA-60DDE276644B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.FeatureManagement.FeatureFilters;
+using System;
+using System.Threading.Tasks;
+
+namespace EvaluationDataToApplicationInsights.Telemetry
+{
+    /// <summary>
+    /// Used to add targeting information to http context. This allows synronous code to access targeting information.
+    /// </summary>
+    public class TargetingHttpContextMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        /// <summary>
+        /// Creates an instance of the TargetingHttpContextMiddleware
+        /// </summary>
+        public TargetingHttpContextMiddleware(RequestDelegate next) { 
+            _next = next; 
+        }
+
+        /// <summary>
+        /// Adds targeting information to the http context.
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/> to add the targeting information to.</param>
+        /// <param name="targetingContextAccessor">The <see cref="ITargetingContextAccessor"/> to retrieve the targeting information from.</param>
+        /// <exception cref="ArgumentNullException">Thrown if the provided context or targetingContextAccessor is null.</exception>
+        public async Task InvokeAsync(HttpContext context, ITargetingContextAccessor targetingContextAccessor)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (targetingContextAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(targetingContextAccessor));
+            }
+
+            TargetingContext targetingContext = await targetingContextAccessor.GetContextAsync().ConfigureAwait(false);
+
+            if (targetingContext != null)
+            {
+                context.Items["TargetingId"] = targetingContext.UserId;
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
@@ -8,7 +8,7 @@ using Microsoft.FeatureManagement.FeatureFilters;
 using System;
 using System.Threading.Tasks;
 
-namespace EvaluationDataToApplicationInsights.Telemetry
+namespace Microsoft.FeatureManagement
 {
     /// <summary>
     /// Used to add targeting information to HTTP context.
@@ -24,7 +24,7 @@ namespace EvaluationDataToApplicationInsights.Telemetry
         /// Creates an instance of the TargetingHttpContextMiddleware
         /// </summary>
         public TargetingHttpContextMiddleware(RequestDelegate next, ILoggerFactory loggerFactory) {
-            _next = next;
+            _next = next ?? throw new ArgumentNullException(nameof(next));
             _logger = loggerFactory?.CreateLogger<TargetingHttpContextMiddleware>() ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 

--- a/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace EvaluationDataToApplicationInsights.Telemetry
 {
     /// <summary>
-    /// Used to add targeting information to http context. This allows synronous code to access targeting information.
+    /// Used to add targeting information to HTTP context.
     /// </summary>
     public class TargetingHttpContextMiddleware
     {
@@ -29,7 +29,7 @@ namespace EvaluationDataToApplicationInsights.Telemetry
         }
 
         /// <summary>
-        /// Adds targeting information to the http context.
+        /// Adds targeting information to the HTTP context.
         /// </summary>
         /// <param name="context">The <see cref="HttpContext"/> to add the targeting information to.</param>
         /// <param name="targetingContextAccessor">The <see cref="ITargetingContextAccessor"/> to retrieve the targeting information from.</param>

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\NugetProperties.props" />
+
+  <!-- Official Version -->
+  <PropertyGroup>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+    <PreviewVersion>-preview</PreviewVersion>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\Versioning.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\build\Microsoft.FeatureManagement.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore provides a solution for tagging Application Insights telemetry with Microsoft.FeatureManagement targeting information.</Description>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <PackageLicenseUrl>https://licenses.nuget.org/MIT</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/Azure/AppConfiguration</PackageProjectUrl>
+    <PackageReleaseNotes>Release notes can be found at https://aka.ms/MicrosoftFeatureManagementReleaseNotes</PackageReleaseNotes>
+    <PackageTags>Microsoft FeatureManagement FeatureFlags ApplicationInsights</PackageTags>
+    <PackageIconUrl>https://aka.ms/AzureAppConfigurationPackageIcon</PackageIconUrl>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.FeatureManagement\Microsoft.FeatureManagement.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\XMLComments\$(MSBuildProjectName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+    <Copy SourceFiles="$(DocumentationFile)" DestinationFolder="$(OutDir)\XMLComments" SkipUnchangedFiles="false" />
+  </Target>
+
+</Project>

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -14,6 +14,8 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
     /// </summary>
     public class TargetingTelemetryInitializer : TelemetryInitializerBase
     {
+        private const string TargetingIdKey = $"Microsoft.FeatureManagement.TargetingId";
+
         /// <summary>
         /// Creates an instance of the TargetingTelemetryInitializer
         /// </summary>
@@ -45,7 +47,8 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
                 throw new ArgumentNullException("httpContext");
             }
 
-            string targetingId = (string) httpContext.Items["TargetingId"];
+            // Extract the targeting id from the http context
+            string targetingId = httpContext.Items[TargetingIdKey]?.ToString();
 
             if (!string.IsNullOrEmpty(targetingId))
             {

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+
+using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
+{
+    /// <summary>
+    /// Used to add targeting information to outgoing Application Insights telemetry.
+    /// </summary>
+    public class TargetingTelemetryInitializer : TelemetryInitializerBase
+    {
+        /// <summary>
+        /// Creates an instance of the TargetingTelemetryInitializer
+        /// </summary>
+        public TargetingTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        {
+        }
+
+        /// <summary>
+        /// When telemetry is initialized, adds targeting information to all relevant telemetry.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> to get the targeting information from.</param>
+        /// <param name="requestTelemetry">The <see cref="RequestTelemetry"/> relevant to the telemetry.</param>
+        /// <param name="telemetry">The <see cref="ITelemetry"/> to be initialized.</param>
+        /// <exception cref="ArgumentNullException">Thrown if the any param is null.</exception>
+        protected override void OnInitializeTelemetry(HttpContext httpContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)
+        {
+            if (telemetry == null)
+            {
+                throw new ArgumentNullException("telemetry");
+            }
+
+            if (requestTelemetry == null)
+            {
+                throw new ArgumentNullException("requestTelemetry");
+            }
+
+            if (httpContext == null)
+            {
+                throw new ArgumentNullException("httpContext");
+            }
+
+            string targetingId = (string) httpContext.Items["TargetingId"];
+
+            if (!string.IsNullOrEmpty(targetingId))
+            {
+                requestTelemetry.Properties["TargetingId"] = targetingId;
+
+                // Telemetry.Properties is deprecated in favor of ISupportProperties
+                if (telemetry is ISupportProperties telemetryWithSupportProperties)
+                {
+                    telemetryWithSupportProperties.Properties["TargetingId"] = targetingId;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -37,23 +37,21 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
                 throw new ArgumentNullException("telemetry");
             }
 
-            if (requestTelemetry == null)
-            {
-                throw new ArgumentNullException("requestTelemetry");
-            }
-
             if (httpContext == null)
             {
                 throw new ArgumentNullException("httpContext");
             }
 
             // Extract the targeting id from the http context
-            string targetingId = httpContext.Items[TargetingIdKey]?.ToString();
+            string targetingId = null;
+
+            if (httpContext.Items.TryGetValue(TargetingIdKey, out object value))
+            {
+                targetingId = value?.ToString();
+            }
 
             if (!string.IsNullOrEmpty(targetingId))
             {
-                requestTelemetry.Properties["TargetingId"] = targetingId;
-
                 // Telemetry.Properties is deprecated in favor of ISupportProperties
                 if (telemetry is ISupportProperties telemetryWithSupportProperties)
                 {


### PR DESCRIPTION
This PR introduces the idea of `TargetingId`. This is separate from UserId, although commonly they may be the same value. `TargetingId` is used to reflect which id was actually used for Feature Evaluation. This `TargetingId` can be tagged on events & metrics to connect events to evaluation events, emitted from a telemetry publisher. 

### `TargetingTelemetryInitializer` 

This was added in a new project, `Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore`. `TargetingTelemetryInitializer` is only relevant for Application Insights telemetry in ASP.NET Core.

### `TargetingHttpContextMiddleware`

This was added to `Microsoft.FeatureManagement.AspNetCore`. `TargetingHttpContextMiddleware` simply adds the TargetingId to HttpContext to enable Synchronous code to quickly access it. This is helpful for things like Telemetry Initializers. 

### Example

The example will be updated in a separate PR. To see how the example will change / how customers would use these new classes, see https://github.com/microsoft/FeatureManagement-Dotnet/compare/rossgrambo/targeting-id-example...rossgrambo/example-update-targeting-id?expand=1