### PR TITLE
Add feature management prefix for cache key

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -301,7 +301,7 @@ namespace Microsoft.FeatureManagement
 
             ConfigurationCacheItem cacheItem;
 
-            string cacheKey = $"{context.FeatureName}.{filterIndex}";
+            string cacheKey = $"Microsoft.FeatureManagement{Environment.NewLine}{context.FeatureName}{Environment.NewLine}{filterIndex}";
 
             //
             // Check if settings already bound from configuration or the parameters have changed


### PR DESCRIPTION
I found that the cache key for feature filter settings is different in preview branch. The cache key will have a prefix of "FeatureManagement". I think this is better.
https://github.com/microsoft/FeatureManagement-Dotnet/blob/preview/src/Microsoft.FeatureManagement/FeatureManager.cs#L666