### PR TITLE
Adjusts FeatureManager private methods from Task to ValueTask

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -256,7 +256,7 @@ namespace Microsoft.FeatureManagement
             return evaluationEvent.Variant;
         }
 
-        private async Task<EvaluationEvent> EvaluateFeature<TContext>(string feature, TContext context, bool useContext, CancellationToken cancellationToken)
+        private async ValueTask<EvaluationEvent> EvaluateFeature<TContext>(string feature, TContext context, bool useContext, CancellationToken cancellationToken)
         {
             var evaluationEvent = new EvaluationEvent
             {
@@ -362,7 +362,7 @@ namespace Microsoft.FeatureManagement
             return evaluationEvent;
         }
 
-        private async Task<bool> IsEnabledAsync<TContext>(FeatureDefinition featureDefinition, TContext appContext, bool useAppContext, CancellationToken cancellationToken)
+        private async ValueTask<bool> IsEnabledAsync<TContext>(FeatureDefinition featureDefinition, TContext appContext, bool useAppContext, CancellationToken cancellationToken)
         {
             Debug.Assert(featureDefinition != null);
 


### PR DESCRIPTION
Went through every Task in our library and tried to switch them to ValueTask without affecting the public interface. These are the only ones that could change.