### PR TITLE
Rename testcase

### DIFF
--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -107,7 +107,7 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task ReadsFeatureFlagsArraySchema()
+        public async Task ReadsMicrosoftFeatureFlagSchema()
         {
             string json = @"
             {


### PR DESCRIPTION
We have decided to use the word "Microsoft Feature Flag schema" as discussed in the email.

I forgot to change the name in testcase in this PR #319 .