### PR TITLE
Add a constructor without FeatureManagementOption parameter for FeatureManager

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -38,49 +38,18 @@ namespace Microsoft.FeatureManagement
         /// Creates a feature manager.
         /// </summary>
         /// <param name="featureDefinitionProvider">The provider of feature flag definitions.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureDefinitionProvider"/> is null.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
-        public FeatureManager(IFeatureDefinitionProvider featureDefinitionProvider)
-        {
-            _filterMetadataCache = new ConcurrentDictionary<string, IFeatureFilterMetadata>();
-            _contextualFeatureFilterCache = new ConcurrentDictionary<string, ContextualFeatureFilterEvaluator>();
-            _featureDefinitionProvider = featureDefinitionProvider ?? throw new ArgumentNullException(nameof(featureDefinitionProvider));
-            _options = new FeatureManagementOptions();
-            _featureFilters = Enumerable.Empty<IFeatureFilterMetadata>();
-            _sessionManagers = Enumerable.Empty<ISessionManager>();
-        }
-
-        /// <summary>
-        /// Creates a feature manager.
-        /// </summary>
-        /// <param name="featureDefinitionProvider">The provider of feature flag definitions.</param>
         /// <param name="options">Options controlling the behavior of the feature manager.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureDefinitionProvider"/> is null.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
         public FeatureManager(
             IFeatureDefinitionProvider featureDefinitionProvider,
-            FeatureManagementOptions options)
+            FeatureManagementOptions options = null)
         {
             _filterMetadataCache = new ConcurrentDictionary<string, IFeatureFilterMetadata>();
             _contextualFeatureFilterCache = new ConcurrentDictionary<string, ContextualFeatureFilterEvaluator>();
             _featureDefinitionProvider = featureDefinitionProvider ?? throw new ArgumentNullException(nameof(featureDefinitionProvider));
-            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _options = options ?? new FeatureManagementOptions();
             _featureFilters = Enumerable.Empty<IFeatureFilterMetadata>();
             _sessionManagers = Enumerable.Empty<ISessionManager>();
-        }
-
-        /// <summary>
-        /// Options controlling the behavior of the feature manager.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown if it is set to null.</exception>
-        public FeatureManagementOptions Options
-        {
-            get => _options;
-
-            init
-            {
-                _options = value ?? throw new ArgumentNullException(nameof(value));
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -38,6 +38,22 @@ namespace Microsoft.FeatureManagement
         /// Creates a feature manager.
         /// </summary>
         /// <param name="featureDefinitionProvider">The provider of feature flag definitions.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureDefinitionProvider"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
+        public FeatureManager(IFeatureDefinitionProvider featureDefinitionProvider)
+        {
+            _filterMetadataCache = new ConcurrentDictionary<string, IFeatureFilterMetadata>();
+            _contextualFeatureFilterCache = new ConcurrentDictionary<string, ContextualFeatureFilterEvaluator>();
+            _featureDefinitionProvider = featureDefinitionProvider ?? throw new ArgumentNullException(nameof(featureDefinitionProvider));
+            _options = new FeatureManagementOptions();
+            _featureFilters = Enumerable.Empty<IFeatureFilterMetadata>();
+            _sessionManagers = Enumerable.Empty<ISessionManager>();
+        }
+
+        /// <summary>
+        /// Creates a feature manager.
+        /// </summary>
+        /// <param name="featureDefinitionProvider">The provider of feature flag definitions.</param>
         /// <param name="options">Options controlling the behavior of the feature manager.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureDefinitionProvider"/> is null.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
@@ -51,6 +67,20 @@ namespace Microsoft.FeatureManagement
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _featureFilters = Enumerable.Empty<IFeatureFilterMetadata>();
             _sessionManagers = Enumerable.Empty<ISessionManager>();
+        }
+
+        /// <summary>
+        /// Options controlling the behavior of the feature manager.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if it is set to null.</exception>
+        public FeatureManagementOptions Options
+        {
+            get => _options;
+
+            init
+            {
+                _options = value ?? throw new ArgumentNullException(nameof(value));
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -43,9 +43,9 @@ namespace Microsoft.FeatureManagement
             services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
 
             services.AddSingleton<IFeatureManager>(sp => new FeatureManager(
-                sp.GetRequiredService<IFeatureDefinitionProvider>(),
-                sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value)
+                sp.GetRequiredService<IFeatureDefinitionProvider>())
             {
+                Options = sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value,
                 FeatureFilters = sp.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>(),
                 SessionManagers = sp.GetRequiredService<IEnumerable<ISessionManager>>(),
                 Cache = sp.GetRequiredService<IMemoryCache>(),
@@ -115,9 +115,9 @@ namespace Microsoft.FeatureManagement
             services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
 
             services.AddScoped<IFeatureManager>(sp => new FeatureManager(
-                sp.GetRequiredService<IFeatureDefinitionProvider>(),
-                sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value)
+                sp.GetRequiredService<IFeatureDefinitionProvider>())
             {
+                Options = sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value,
                 FeatureFilters = sp.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>(),
                 SessionManagers = sp.GetRequiredService<IEnumerable<ISessionManager>>(),
                 Cache = sp.GetRequiredService<IMemoryCache>(),

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -43,9 +43,9 @@ namespace Microsoft.FeatureManagement
             services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
 
             services.AddSingleton<IFeatureManager>(sp => new FeatureManager(
-                sp.GetRequiredService<IFeatureDefinitionProvider>())
+                sp.GetRequiredService<IFeatureDefinitionProvider>(),
+                sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value)
             {
-                Options = sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value,
                 FeatureFilters = sp.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>(),
                 SessionManagers = sp.GetRequiredService<IEnumerable<ISessionManager>>(),
                 Cache = sp.GetRequiredService<IMemoryCache>(),
@@ -115,9 +115,9 @@ namespace Microsoft.FeatureManagement
             services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
 
             services.AddScoped<IFeatureManager>(sp => new FeatureManager(
-                sp.GetRequiredService<IFeatureDefinitionProvider>())
+                sp.GetRequiredService<IFeatureDefinitionProvider>(),
+                sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value)
             {
-                Options = sp.GetRequiredService<IOptions<FeatureManagementOptions>>().Value,
                 FeatureFilters = sp.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>(),
                 SessionManagers = sp.GetRequiredService<IEnumerable<ISessionManager>>(),
                 Cache = sp.GetRequiredService<IMemoryCache>(),


### PR DESCRIPTION
According to https://github.com/MicrosoftDocs/azure-docs-pr/pull/264613#discussion_r1475561565

This change will simplify the non-DI usage of feature management a little bit.