### PR TITLE
Avoid redundant validation for cached TargetingFilterSettings

### DIFF
--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -38,7 +38,14 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns><see cref="TargetingFilterSettings"/> that can later be used in targeting.</returns>
         public object BindParameters(IConfiguration filterParameters)
         {
-            return filterParameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
+            TargetingFilterSettings settings = filterParameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
+
+            if (!TargetingEvaluator.TryValidateSettings(settings, out string paramName, out string reason))
+            {
+                throw new ArgumentException(reason, paramName);
+            }
+
+            return settings;
         }
 
         /// <summary>

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingEvaluator.cs
@@ -21,6 +21,70 @@ namespace Microsoft.FeatureManagement.Targeting
         const string RequiredParameter = "Value cannot be null.";
 
         /// <summary>
+        /// Performs validation of targeting settings.
+        /// </summary>
+        /// <param name="targetingSettings">The settings to validate.</param>
+        /// <param name="paramName">The name of the invalid setting, if any.</param>
+        /// <param name="reason">The reason that the setting is invalid.</param>
+        /// <returns>True if the provided settings are valid. False if the provided settings are invalid.</returns>
+        public static bool TryValidateSettings(TargetingFilterSettings targetingSettings, out string paramName, out string reason)
+        {
+            paramName = null;
+
+            reason = null;
+
+            if (targetingSettings == null)
+            {
+                paramName = nameof(targetingSettings);
+
+                reason = RequiredParameter;
+
+                return false;
+            }
+
+            if (targetingSettings.Audience == null)
+            {
+                paramName = nameof(targetingSettings.Audience);
+
+                reason = RequiredParameter;
+
+                return false;
+            }
+
+            if (targetingSettings.Audience.DefaultRolloutPercentage < 0 || targetingSettings.Audience.DefaultRolloutPercentage > 100)
+            {
+                paramName = $"{targetingSettings.Audience}.{targetingSettings.Audience.DefaultRolloutPercentage}";
+
+                reason = OutOfRange;
+
+                return false;
+            }
+
+            if (targetingSettings.Audience.Groups != null)
+            {
+                int index = 0;
+
+                foreach (GroupRollout groupRollout in targetingSettings.Audience.Groups)
+                {
+                    index++;
+
+                    if (groupRollout.RolloutPercentage < 0 || groupRollout.RolloutPercentage > 100)
+                    {
+                        //
+                        // Audience.Groups[1].RolloutPercentage
+                        paramName = $"{targetingSettings.Audience}.{targetingSettings.Audience.Groups}[{index}].{groupRollout.RolloutPercentage}";
+
+                        reason = OutOfRange;
+
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Checks if a provided targeting context should be targeted given targeting settings.
         /// </summary>
         public static bool IsTargeted(ITargetingContext targetingContext, TargetingFilterSettings settings, bool ignoreCase, string hint)
@@ -222,70 +286,6 @@ namespace Microsoft.FeatureManagement.Targeting
             string defaultContextId = $"{userId}\n{hint}";
 
             return IsTargeted(defaultContextId, 0, defaultRolloutPercentage);
-        }
-
-        /// <summary>
-        /// Performs validation of targeting settings.
-        /// </summary>
-        /// <param name="targetingSettings">The settings to validate.</param>
-        /// <param name="paramName">The name of the invalid setting, if any.</param>
-        /// <param name="reason">The reason that the setting is invalid.</param>
-        /// <returns>True if the provided settings are valid. False if the provided settings are invalid.</returns>
-        public static bool TryValidateSettings(TargetingFilterSettings targetingSettings, out string paramName, out string reason)
-        {
-            paramName = null;
-
-            reason = null;
-
-            if (targetingSettings == null)
-            {
-                paramName = nameof(targetingSettings);
-
-                reason = RequiredParameter;
-
-                return false;
-            }
-
-            if (targetingSettings.Audience == null)
-            {
-                paramName = nameof(targetingSettings.Audience);
-
-                reason = RequiredParameter;
-
-                return false;
-            }
-
-            if (targetingSettings.Audience.DefaultRolloutPercentage < 0 || targetingSettings.Audience.DefaultRolloutPercentage > 100)
-            {
-                paramName = $"{targetingSettings.Audience}.{targetingSettings.Audience.DefaultRolloutPercentage}";
-
-                reason = OutOfRange;
-
-                return false;
-            }
-
-            if (targetingSettings.Audience.Groups != null)
-            {
-                int index = 0;
-
-                foreach (GroupRollout groupRollout in targetingSettings.Audience.Groups)
-                {
-                    index++;
-
-                    if (groupRollout.RolloutPercentage < 0 || groupRollout.RolloutPercentage > 100)
-                    {
-                        //
-                        // Audience.Groups[1].RolloutPercentage
-                        paramName = $"{targetingSettings.Audience}.{targetingSettings.Audience.Groups}[{index}].{groupRollout.RolloutPercentage}";
-
-                        reason = OutOfRange;
-
-                        return false;
-                    }
-                }
-            }
-
-            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingEvaluator.cs
@@ -35,11 +35,6 @@ namespace Microsoft.FeatureManagement.Targeting
                 throw new ArgumentNullException(nameof(targetingContext));
             }
 
-            if (!TryValidateSettings(settings, out string paramName, out string reason))
-            {
-                throw new ArgumentException(reason, paramName);
-            }
-
             if (settings.Audience.Exclusion != null)
             {
                 //
@@ -236,7 +231,7 @@ namespace Microsoft.FeatureManagement.Targeting
         /// <param name="paramName">The name of the invalid setting, if any.</param>
         /// <param name="reason">The reason that the setting is invalid.</param>
         /// <returns>True if the provided settings are valid. False if the provided settings are invalid.</returns>
-        private static bool TryValidateSettings(TargetingFilterSettings targetingSettings, out string paramName, out string reason)
+        public static bool TryValidateSettings(TargetingFilterSettings targetingSettings, out string paramName, out string reason)
         {
             paramName = null;
 

--- a/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/TargetingFilter.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement.Targeting;
 using System;
 using System.Threading.Tasks;
 
@@ -40,7 +41,14 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// <returns><see cref="TargetingFilterSettings"/> that can later be used in targeting.</returns>
         public object BindParameters(IConfiguration filterParameters)
         {
-            return filterParameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
+            TargetingFilterSettings settings = filterParameters.Get<TargetingFilterSettings>() ?? new TargetingFilterSettings();
+
+            if (!TargetingEvaluator.TryValidateSettings(settings, out string paramName, out string reason))
+            {
+                throw new ArgumentException(reason, paramName);
+            }
+
+            return settings;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, the validation of TargetingFilterSettings will happened on every request, which is unnecessary. 

Usually, filter settings will be prebound and be cached in the feature manager. It will be passed to the feature filter as part of `FeatureFilterEvaluationContext`. The `BindParameters` method will only be called once and there is only one filter settings. 

So, I propose to move the settings validation to `TargetingFilter.BindParameters` from `TargetingEvaluator.IsTargeted`.