### PR TITLE
Optional Cancellation Token

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -348,7 +348,7 @@ namespace Microsoft.FeatureManagement
 
                 foreach (ISessionManager sessionManager in _sessionManagers)
                 {
-                    await sessionManager.SetAsync(evaluationEvent.FeatureDefinition.Name, evaluationEvent.Enabled, cancellationToken).ConfigureAwait(false);
+                    await sessionManager.SetAsync(evaluationEvent.FeatureDefinition.Name, evaluationEvent.Enabled).ConfigureAwait(false);
                 }
 
                 if (evaluationEvent.FeatureDefinition.Telemetry != null &&
@@ -367,7 +367,7 @@ namespace Microsoft.FeatureManagement
 
             foreach (ISessionManager sessionManager in _sessionManagers)
             {
-                bool? readSessionResult = await sessionManager.GetAsync(featureDefinition.Name, cancellationToken).ConfigureAwait(false);
+                bool? readSessionResult = await sessionManager.GetAsync(featureDefinition.Name).ConfigureAwait(false);
 
                 if (readSessionResult.HasValue)
                 {

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -169,7 +169,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to check.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        public async ValueTask<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken)
+        public async ValueTask<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken = default)
         {
             EvaluationEvent evaluationEvent = await EvaluateFeature<object>(feature, context: null, useContext: false, cancellationToken);
 
@@ -183,7 +183,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="appContext">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        public async ValueTask<bool> IsEnabledAsync<TContext>(string feature, TContext appContext, CancellationToken cancellationToken)
+        public async ValueTask<bool> IsEnabledAsync<TContext>(string feature, TContext appContext, CancellationToken cancellationToken = default)
         {
             EvaluationEvent evaluationEvent = await EvaluateFeature(feature, context: appContext, useContext: true, cancellationToken);
 
@@ -203,7 +203,7 @@ namespace Microsoft.FeatureManagement
         /// Retrieves a list of feature names registered in the feature manager.
         /// </summary>
         /// <returns>An enumerator which provides asynchronous iteration over the feature names registered in the feature manager.</returns>
-        public async IAsyncEnumerable<string> GetFeatureNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<string> GetFeatureNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await foreach (FeatureDefinition featureDefinition in _featureDefinitionProvider.GetAllFeatureDefinitionsAsync().ConfigureAwait(false))
             {
@@ -219,7 +219,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to evaluate.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A variant assigned to the user based on the feature's configured allocation.</returns>
-        public async ValueTask<Variant> GetVariantAsync(string feature, CancellationToken cancellationToken)
+        public async ValueTask<Variant> GetVariantAsync(string feature, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(feature))
             {
@@ -238,7 +238,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="context">An instance of <see cref="TargetingContext"/> used to evaluate which variant the user will be assigned.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A variant assigned to the user based on the feature's configured allocation.</returns>
-        public async ValueTask<Variant> GetVariantAsync(string feature, TargetingContext context, CancellationToken cancellationToken)
+        public async ValueTask<Variant> GetVariantAsync(string feature, TargetingContext context, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(feature))
             {
@@ -348,7 +348,7 @@ namespace Microsoft.FeatureManagement
 
                 foreach (ISessionManager sessionManager in _sessionManagers)
                 {
-                    await sessionManager.SetAsync(evaluationEvent.FeatureDefinition.Name, evaluationEvent.Enabled).ConfigureAwait(false);
+                    await sessionManager.SetAsync(evaluationEvent.FeatureDefinition.Name, evaluationEvent.Enabled, cancellationToken).ConfigureAwait(false);
                 }
 
                 if (evaluationEvent.FeatureDefinition.Telemetry != null &&
@@ -367,7 +367,7 @@ namespace Microsoft.FeatureManagement
 
             foreach (ISessionManager sessionManager in _sessionManagers)
             {
-                bool? readSessionResult = await sessionManager.GetAsync(featureDefinition.Name).ConfigureAwait(false);
+                bool? readSessionResult = await sessionManager.GetAsync(featureDefinition.Name, cancellationToken).ConfigureAwait(false);
 
                 if (readSessionResult.HasValue)
                 {

--- a/src/Microsoft.FeatureManagement/ISessionManager.cs
+++ b/src/Microsoft.FeatureManagement/ISessionManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement
@@ -15,13 +16,15 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="featureName">The name of the feature.</param>
         /// <param name="enabled">The state of the feature.</param>
-        Task SetAsync(string featureName, bool enabled);
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+        Task SetAsync(string featureName, bool enabled, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Queries the session manager for the session's feature state, if any, for the given feature.
         /// </summary>
         /// <param name="featureName">The name of the feature.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The state of the feature if it is present in the session, otherwise null.</returns>
-        Task<bool?> GetAsync(string featureName);
+        Task<bool?> GetAsync(string featureName, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/ISessionManager.cs
+++ b/src/Microsoft.FeatureManagement/ISessionManager.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.FeatureManagement

--- a/src/Microsoft.FeatureManagement/ISessionManager.cs
+++ b/src/Microsoft.FeatureManagement/ISessionManager.cs
@@ -16,15 +16,13 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="featureName">The name of the feature.</param>
         /// <param name="enabled">The state of the feature.</param>
-        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        Task SetAsync(string featureName, bool enabled, CancellationToken cancellationToken = default);
+        Task SetAsync(string featureName, bool enabled);
 
         /// <summary>
         /// Queries the session manager for the session's feature state, if any, for the given feature.
         /// </summary>
         /// <param name="featureName">The name of the feature.</param>
-        /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>The state of the feature if it is present in the session, otherwise null.</returns>
-        Task<bool?> GetAsync(string featureName, CancellationToken cancellationToken = default);
+        Task<bool?> GetAsync(string featureName);
     }
 }

--- a/src/Microsoft.FeatureManagement/IVariantFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IVariantFeatureManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to check.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        ValueTask<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken);
+        ValueTask<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Checks whether a given feature is enabled.
@@ -35,7 +35,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
-        ValueTask<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken);
+        ValueTask<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the assigned variant for a specific feature.
@@ -43,7 +43,7 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to evaluate.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A variant assigned to the user based on the feature's configured allocation.</returns>
-        ValueTask<Variant> GetVariantAsync(string feature, CancellationToken cancellationToken);
+        ValueTask<Variant> GetVariantAsync(string feature, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the assigned variant for a specific feature.
@@ -52,6 +52,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="context">An instance of <see cref="TargetingContext"/> used to evaluate which variant the user will be assigned.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A variant assigned to the user based on the feature's configured allocation.</returns>
-        ValueTask<Variant> GetVariantAsync(string feature, TargetingContext context, CancellationToken cancellationToken);
+        ValueTask<Variant> GetVariantAsync(string feature, TargetingContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/IVariantFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IVariantFeatureManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>An enumerator which provides asynchronous iteration over the feature names registered in the feature manager.</returns>
-        IAsyncEnumerable<string> GetFeatureNamesAsync(CancellationToken cancellationToken);
+        IAsyncEnumerable<string> GetFeatureNamesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Checks whether a given feature is enabled.


### PR DESCRIPTION
According to #376  

BTW, all AppConfig SDK public APIs made the CancellationToken optional: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs

This PR makes cancellation token optional for async methods of IVariantFeatureManager and adds cancellation token to async methods of ISessionManager