### PR TITLE
Adjusts namespace to simply ~.Telemetry

### DIFF
--- a/examples/EvaluationDataToApplicationInsights/Program.cs
+++ b/examples/EvaluationDataToApplicationInsights/Program.cs
@@ -5,7 +5,7 @@ using Microsoft.FeatureManagement.Telemetry;
 using Microsoft.FeatureManagement;
 using EvaluationDataToApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.FeatureManagement.Telemetry.AspNetCore;
+using Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/examples/EvaluationDataToApplicationInsights/Program.cs
+++ b/examples/EvaluationDataToApplicationInsights/Program.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
-using Microsoft.FeatureManagement.Telemetry.ApplicationInsights;
+using Microsoft.FeatureManagement.Telemetry;
 using Microsoft.FeatureManagement;
 using EvaluationDataToApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore;
+using Microsoft.FeatureManagement.Telemetry.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -7,7 +7,7 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Http;
 
-namespace Microsoft.FeatureManagement.Telemetry.AspNetCore
+namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
 {
     /// <summary>
     /// Used to add targeting information to outgoing Application Insights telemetry.

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -7,7 +7,7 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Http;
 
-namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
+namespace Microsoft.FeatureManagement.Telemetry.AspNetCore
 {
     /// <summary>
     /// Used to add targeting information to outgoing Application Insights telemetry.

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryPublisher.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryPublisher.cs
@@ -4,7 +4,7 @@
 using Microsoft.ApplicationInsights;
 using System.Diagnostics;
 
-namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
+namespace Microsoft.FeatureManagement.Telemetry
 {
     /// <summary>
     /// Used to publish data from evaluation events to Application Insights


### PR DESCRIPTION
## Why this PR?

Addresses https://github.com/microsoft/FeatureManagement-Dotnet/issues/392

## Visible Changes

Developers using any of our offered telemetry publishers will use `using Microsoft.FeatureManagement.Telemetry;` and developers using any of our offered telemetry initializers will use `using Microsoft.FeatureManagement.Telemetry.AspNetCore;`. 

We will no longer have service specific namespaces like `using ~.ApplicationInsights.~;` except for extension methods.