### PR TITLE
Adjusts ApplicationInsights extension methods namespace

### DIFF
--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
-using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.FeatureManagement.FeatureFilters;
 
-namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
+namespace Microsoft.ApplicationInsights
 {
     /// <summary>
     /// Provides extension methods for tracking events with <see cref="TargetingContext"/>.

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ApplicationInsights
     /// <summary>
     /// Provides extension methods for tracking events with <see cref="TargetingContext"/>.
     /// </summary>
-    public static class TelemetryClientExtensions
+    public static class FeatureManagementTelemetryClientExtensions
     {
         /// <summary>
         /// Extension method to track an event with <see cref="TargetingContext"/>.


### PR DESCRIPTION
## Why this PR?

Addresses https://github.com/microsoft/FeatureManagement-Dotnet/issues/391

## Visible Changes

Developers using our Application Insights extension methods will have the methods available from their existing `using Microsoft.ApplicationInsights;`.

Developers no longer require the `using Microsoft.FeatureManagement.Telemetry.ApplicationInsights;`.