### PR TITLE
Warning log missing targeting context accessor

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -314,11 +314,16 @@ namespace Microsoft.FeatureManagement
                         {
                             string message;
 
-                            if (useContext) {
+                            if (useContext) 
+                            {
                                 message = $"A {nameof(TargetingContext)} required for variant assignment was not provided.";
-                            } else if (TargetingContextAccessor == null) {
+                            } 
+                            else if (TargetingContextAccessor == null) 
+                            {
                                 message = $"No instance of {nameof(ITargetingContextAccessor)} could be found for variant assignment.";
-                            } else {
+                            } 
+                            else 
+                            {
                                 message = $"No instance of {nameof(TargetingContext)} could be found using {nameof(ITargetingContextAccessor)} for variant assignment.";
                             }
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -312,13 +312,9 @@ namespace Microsoft.FeatureManagement
                     {
                         if (targetingContext == null)
                         {
-                            if (useContext)
-                            {
-                                Logger?.LogWarning($"The {nameof(TargetingContext)} required for variant assignment was not provided.");
-                            } else
-                            {
-                                Logger?.LogWarning($"The {nameof(TargetingContext)} required for variant assignment was not retrieved from the {nameof(ITargetingContextAccessor)}.");
-                            }
+                            Logger?.LogWarning(useContext ?
+                                $"The {nameof(TargetingContext)} required for variant assignment was not provided." :
+                                $"The {nameof(TargetingContext)} required for variant assignment was not retrieved from the {nameof(ITargetingContextAccessor)}.");
                         }
 
                         if (targetingContext != null && evaluationEvent.FeatureDefinition.Allocation != null)

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -312,7 +312,13 @@ namespace Microsoft.FeatureManagement
                     {
                         if (targetingContext == null)
                         {
-                            Logger?.LogWarning($"No instance of {nameof(TargetingContext)} was explicitly passed or could be found using {nameof(ITargetingContextAccessor)} for variant assignment.");
+                            if (useContext)
+                            {
+                                Logger?.LogWarning($"The {nameof(TargetingContext)} required for variant assignment was not provided.");
+                            } else
+                            {
+                                Logger?.LogWarning($"The {nameof(TargetingContext)} required for variant assignment was not retrieved from the {nameof(ITargetingContextAccessor)}.");
+                            }
                         }
 
                         if (targetingContext != null && evaluationEvent.FeatureDefinition.Allocation != null)

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -310,6 +310,11 @@ namespace Microsoft.FeatureManagement
                     }
                     else
                     {
+                        if (targetingContext == null)
+                        {
+                            Logger?.LogWarning($"No instance of {nameof(TargetingContext)} was explicitly passed or could be found using {nameof(ITargetingContextAccessor)} for variant assignment.");
+                        }
+
                         if (targetingContext != null && evaluationEvent.FeatureDefinition.Allocation != null)
                         {
                             variantDefinition = await AssignVariantAsync(evaluationEvent, targetingContext, cancellationToken).ConfigureAwait(false);
@@ -527,21 +532,12 @@ namespace Microsoft.FeatureManagement
         {
             if (TargetingContextAccessor == null)
             {
-                Logger?.LogWarning($"No instance of {nameof(ITargetingContextAccessor)} is available for variant assignment.");
-
                 return null;
             }
 
             //
             // Acquire targeting context via accessor
             TargetingContext context = await TargetingContextAccessor.GetContextAsync().ConfigureAwait(false);
-
-            //
-            // Ensure targeting can be performed
-            if (context == null)
-            {
-                Logger?.LogWarning($"No instance of {nameof(TargetingContext)} could be found using {nameof(ITargetingContextAccessor)} for variant assignment.");
-            }
 
             return context;
         }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -312,9 +312,17 @@ namespace Microsoft.FeatureManagement
                     {
                         if (targetingContext == null)
                         {
-                            Logger?.LogWarning(useContext ?
-                                $"The {nameof(TargetingContext)} required for variant assignment was not provided." :
-                                $"The {nameof(TargetingContext)} required for variant assignment was not retrieved from the {nameof(ITargetingContextAccessor)}.");
+                            string message;
+
+                            if (useContext) {
+                                message = $"A {nameof(TargetingContext)} required for variant assignment was not provided.";
+                            } else if (TargetingContextAccessor == null) {
+                                message = $"A {nameof(ITargetingContextAccessor)} was not provided. The {nameof(TargetingContext)} required for variant assignment will be null.";
+                            } else {
+                                message = $"No instance of {nameof(TargetingContext)} could be found using {nameof(ITargetingContextAccessor)} for variant assignment.";
+                            }
+
+                            Logger?.LogWarning(message);
                         }
 
                         if (targetingContext != null && evaluationEvent.FeatureDefinition.Allocation != null)

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -317,7 +317,7 @@ namespace Microsoft.FeatureManagement
                             if (useContext) {
                                 message = $"A {nameof(TargetingContext)} required for variant assignment was not provided.";
                             } else if (TargetingContextAccessor == null) {
-                                message = $"A {nameof(ITargetingContextAccessor)} was not provided. The {nameof(TargetingContext)} required for variant assignment will be null.";
+                                message = $"No instance of {nameof(ITargetingContextAccessor)} could be found for variant assignment.";
                             } else {
                                 message = $"No instance of {nameof(TargetingContext)} could be found using {nameof(ITargetingContextAccessor)} for variant assignment.";
                             }


### PR DESCRIPTION
## Why this PR?
Adjusts warning logs identified in https://github.com/microsoft/FeatureManagement-Dotnet/issues/425

## Visible Changes
Developers will no longer see this warning when using flags that don't require TargetingContext.
```
No instance of ITargetingContextAccessor is available for variant assignment.
```
This warning will only show if they have variants defined and we've reached the place in code where allocation would happen.
