### PR TITLE
TelemetryInitializer, Middleware, and TargetingContext rework

### DIFF
--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/Constants.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/Constants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
+{
+    internal class Constants
+    {
+        public const string TargetingIdKey = "TargetingId";
+    }
+}

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingHttpContextMiddleware.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingHttpContextMiddleware.cs
@@ -28,14 +28,14 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
         /// <summary>
         /// Adds targeting information to the HTTP context.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> to add the targeting information to.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> to add the targeting information to.</param>
         /// <param name="targetingContextAccessor">The <see cref="ITargetingContextAccessor"/> to retrieve the targeting information from.</param>
         /// <exception cref="ArgumentNullException">Thrown if the provided context or targetingContextAccessor is null.</exception>
-        public async Task InvokeAsync(HttpContext context, ITargetingContextAccessor targetingContextAccessor)
+        public async Task InvokeAsync(HttpContext httpContext, ITargetingContextAccessor targetingContextAccessor)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
             if (targetingContextAccessor == null)
@@ -47,11 +47,11 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
 
             if (targetingContext != null)
             {
-                var requestTelemetry = context.Features.Get<RequestTelemetry>();
+                var requestTelemetry = httpContext.Features.Get<RequestTelemetry>();
 
                 if (requestTelemetry != null)
                 {
-                    requestTelemetry.Properties.Add(Constants.TargetingIdKey, targetingContext.UserId);
+                    requestTelemetry.Properties[Constants.TargetingIdKey] = targetingContext.UserId;
                 }
             }
             else
@@ -59,7 +59,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
                 _logger.LogDebug("The targeting context accessor returned a null TargetingContext");
             }
 
-            await _next(context);
+            await _next(httpContext);
         }
     }
 }

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingHttpContextMiddleware.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingHttpContextMiddleware.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT license.
 //
 
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement.FeatureFilters;
-using System;
-using System.Threading.Tasks;
 
-namespace Microsoft.FeatureManagement
+namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
 {
     /// <summary>
     /// Used to add targeting information to HTTP context.
@@ -17,8 +16,6 @@ namespace Microsoft.FeatureManagement
     {
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
-
-        private const string TargetingIdKey = $"Microsoft.FeatureManagement.TargetingId";
 
         /// <summary>
         /// Creates an instance of the TargetingHttpContextMiddleware
@@ -50,7 +47,12 @@ namespace Microsoft.FeatureManagement
 
             if (targetingContext != null)
             {
-                context.Items[TargetingIdKey] = targetingContext.UserId;
+                var requestTelemetry = context.Features.Get<RequestTelemetry>();
+
+                if (requestTelemetry != null)
+                {
+                    requestTelemetry.Properties.Add(Constants.TargetingIdKey, targetingContext.UserId);
+                }
             }
             else
             {

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -14,8 +14,6 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
     /// </summary>
     public class TargetingTelemetryInitializer : TelemetryInitializerBase
     {
-        private const string TargetingIdKey = $"Microsoft.FeatureManagement.TargetingId";
-
         /// <summary>
         /// Creates an instance of the TargetingTelemetryInitializer
         /// </summary>
@@ -42,20 +40,13 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            // Extract the targeting id from the http context
-            string targetingId = null;
-
-            if (httpContext.Items.TryGetValue(TargetingIdKey, out object value))
-            {
-                targetingId = value?.ToString();
-            }
-
-            if (!string.IsNullOrEmpty(targetingId))
+            // Extract the targeting id from the request telemetry
+            if (requestTelemetry.Properties.ContainsKey(Constants.TargetingIdKey))
             {
                 // Telemetry.Properties is deprecated in favor of ISupportProperties
                 if (telemetry is ISupportProperties telemetryWithSupportProperties)
                 {
-                    telemetryWithSupportProperties.Properties["TargetingId"] = targetingId;
+                    telemetryWithSupportProperties.Properties[Constants.TargetingIdKey] = requestTelemetry.Properties[Constants.TargetingIdKey];
                 }
             }
         }

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore/TargetingTelemetryInitializer.cs
@@ -35,9 +35,9 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights.AspNetCore
                 throw new ArgumentNullException(nameof(telemetry));
             }
 
-            if (httpContext == null)
+            if (requestTelemetry == null)
             {
-                throw new ArgumentNullException(nameof(httpContext));
+                throw new ArgumentNullException(nameof(requestTelemetry));
             }
 
             // Extract the targeting id from the request telemetry

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryPublisher.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsTelemetryPublisher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Microsoft.ApplicationInsights;
+using Microsoft.FeatureManagement.Telemetry.ApplicationInsights;
 using System.Diagnostics;
 
 namespace Microsoft.FeatureManagement.Telemetry
@@ -44,7 +45,7 @@ namespace Microsoft.FeatureManagement.Telemetry
 
             if (evaluationEvent.TargetingContext != null)
             {
-                properties["TargetingId"] = evaluationEvent.TargetingContext.UserId;
+                properties[Constants.TargetingIdKey] = evaluationEvent.TargetingContext.UserId;
             }
 
             if (evaluationEvent.VariantAssignmentReason != VariantAssignmentReason.None)

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/Constants.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/Constants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
+{
+    internal class Constants
+    {
+        public const string TargetingIdKey = "TargetingId";
+    }
+}

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TelemetryClientExtensions.cs
@@ -3,6 +3,7 @@
 //
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.FeatureManagement.FeatureFilters;
+using Microsoft.FeatureManagement.Telemetry.ApplicationInsights;
 
 namespace Microsoft.ApplicationInsights
 {
@@ -23,7 +24,7 @@ namespace Microsoft.ApplicationInsights
                 properties = new Dictionary<string, string>();
             }
 
-            properties["TargetingId"] = targetingContext.UserId;
+            properties[Constants.TargetingIdKey] = targetingContext.UserId;
 
             telemetryClient.TrackEvent(eventName, properties, metrics);
         }
@@ -40,7 +41,7 @@ namespace Microsoft.ApplicationInsights
                 telemetry = new EventTelemetry();
             }
 
-            telemetry.Properties["TargetingId"] = targetingContext.UserId;
+            telemetry.Properties[Constants.TargetingIdKey] = targetingContext.UserId;
 
             telemetryClient.TrackEvent(telemetry);
         }


### PR DESCRIPTION
## Why this PR?

Primarily a refactor. 
Also resolves https://github.com/microsoft/FeatureManagement-Dotnet/issues/424. 
Related to- but explicitly not resolving here since the middleware was moved out of the main AspNetCore package https://github.com/microsoft/FeatureManagement-Dotnet/issues/396.

`ITargetingContextAccessor` is async and could not used reached by `ITelemetryInitializer`. We currently get around this by having our middleware add `TargetingContext` to `HttpContext` so it can be read synchronously.

This PR adjusts the middleware to instead place `TargetingId` on the `RequestTelemetry` object instead. This object is specific to Application Insights and we were already adding `TargetingId` to it with our existing initializer. By adding this earlier, we allow the initializer to depend on this field rather than the key on `HttpContext`. It also allows us to simply use the "TargetingId" key, rather than having a custom one for `HttpContext`.

This also allows `ITargetingContextAccessor` to cache however it wants and we're not caching in multiple places.

In short: Middleware stores on RequestTelemetry instead of HttpContext. Initializer now simply moves fields from RequestTelemetry to other Telemetry (like custom events).

## Visible Changes
`HttpContext` will no longer have the key "Microsoft.FeatureManagement.TargetingId" added to `HttpContext.Items`.