### PR TITLE
Modified FeatureManager to accept optional parameters for FeatureFilters and SessionManagers.

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -39,17 +39,21 @@ namespace Microsoft.FeatureManagement
         /// </summary>
         /// <param name="featureDefinitionProvider">The provider of feature flag definitions.</param>
         /// <param name="options">Options controlling the behavior of the feature manager.</param>
+        /// <param name="featureFilters">The collection of feature filter metadata.</param>
+        /// <param name="sessionManagers">The collection of session managers.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureDefinitionProvider"/> is null.</exception>
         public FeatureManager(
             IFeatureDefinitionProvider featureDefinitionProvider,
-            FeatureManagementOptions options = null)
+            FeatureManagementOptions options = null,
+            IEnumerable<IFeatureFilterMetadata> featureFilters = null,
+            IEnumerable<ISessionManager> sessionManagers = null)
         {
             _filterMetadataCache = new ConcurrentDictionary<string, IFeatureFilterMetadata>();
             _contextualFeatureFilterCache = new ConcurrentDictionary<string, ContextualFeatureFilterEvaluator>();
             _featureDefinitionProvider = featureDefinitionProvider ?? throw new ArgumentNullException(nameof(featureDefinitionProvider));
             _options = options ?? new FeatureManagementOptions();
-            _featureFilters = Enumerable.Empty<IFeatureFilterMetadata>();
-            _sessionManagers = Enumerable.Empty<ISessionManager>();
+            _featureFilters = featureFilters ?? Enumerable.Empty<IFeatureFilterMetadata>();
+            _sessionManagers = sessionManagers ?? Enumerable.Empty<ISessionManager>();
         }
 
         /// <summary>

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -1027,5 +1027,41 @@ namespace Tests.FeatureManagement
 
             Assert.True(called);
         }
+
+        [Fact]
+        public void ConstructorUsesFallbackValues()
+        {
+            var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+            var configDefinitionProvider = new ConfigurationFeatureDefinitionProvider(config);
+            var featureManager = new FeatureManager(configDefinitionProvider);
+
+            Assert.Empty(featureManager.FeatureFilters);
+            Assert.Empty(featureManager.SessionManagers);
+        }
+
+        [Fact]
+        public void ConstructorSetsOptionalValues()
+        {
+            var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+            var configDefinitionProvider = new ConfigurationFeatureDefinitionProvider(config);
+            var options = new FeatureManagementOptions();
+            var featureFilters = new List<IFeatureFilterMetadata>
+            {
+                new TestFilter()
+            };
+            var sessionManagers = new List<ISessionManager>
+            {
+                new TestSessionManager()
+            };
+            var featureManager = new FeatureManager(
+                configDefinitionProvider,
+                options,
+                featureFilters,
+                sessionManagers
+            );
+
+            Assert.Single(featureManager.FeatureFilters);
+            Assert.Single(featureManager.SessionManagers);
+        }
     }
 }

--- a/tests/Tests.FeatureManagement/TestSessionManager.cs
+++ b/tests/Tests.FeatureManagement/TestSessionManager.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.FeatureManagement;
+
+namespace Tests.FeatureManagement
+{
+    class TestSessionManager : ISessionManager
+    {
+        private readonly IDictionary<string, bool> _features = new Dictionary<string, bool>();
+        
+        public Task SetAsync(string featureName, bool enabled)
+        {
+            _features[featureName] = enabled;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool?> GetAsync(string featureName)
+        {
+            bool? result = _features.TryGetValue(featureName, out var feature) ? feature : null;
+
+            return Task.FromResult(result);
+        }
+    }
+}


### PR DESCRIPTION
I'm working on a project which doesn't use IServiceCollection or C# 9, but would benefit from using this library.  In order to do so, I need to be able to set the FeatureFilters property without using `init`.  This PR adds`Enumerable<IFeatureFilterMetadata>` and `IEnumerable<ISessionManager>` as optional parameters to the FeatureManager constructor and uses their existing `Enumerable.Empty` as a fallback.