### PR TITLE
Moves cache busting and handles null

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -381,8 +381,8 @@ namespace Microsoft.FeatureManagement
                     .FirstOrDefault(section =>
                         string.Equals(
                             section.Key,
-                            _microsoftFeatureManagementSchemaEnabled ?
-                                MicrosoftFeatureManagementFields.FeatureManagementSectionName :
+                            _microsoftFeatureManagementSchemaEnabled ? 
+                                MicrosoftFeatureManagementFields.FeatureManagementSectionName : 
                                 ConfigurationFields.FeatureManagementSectionName,
                             StringComparison.OrdinalIgnoreCase));
 

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -115,11 +115,6 @@ namespace Microsoft.FeatureManagement
         public async IAsyncEnumerable<FeatureDefinition> GetAllFeatureDefinitionsAsync()
 #pragma warning restore CS1998
         {
-            if (Interlocked.Exchange(ref _stale, 0) != 0)
-            {
-                _definitions.Clear();
-            }
-
             //
             // Iterate over all features registered in the system at initial invocation time
             foreach (IConfigurationSection featureSection in GetFeatureDefinitionSections())
@@ -129,6 +124,11 @@ namespace Microsoft.FeatureManagement
                 if (string.IsNullOrEmpty(featureName))
                 {
                     continue;
+                }
+
+                if (Interlocked.Exchange(ref _stale, 0) != 0)
+                {
+                    _definitions.Clear();
                 }
 
                 //

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -119,7 +119,7 @@ namespace Microsoft.FeatureManagement
         {
             await foreach (FeatureDefinition featureDefintion in _featureDefinitionProvider.GetAllFeatureDefinitionsAsync().ConfigureAwait(false))
             {
-                yield return featureDefintion.Name;
+                yield return featureDefintion?.Name;
             }
         }
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -119,7 +119,7 @@ namespace Microsoft.FeatureManagement
         {
             await foreach (FeatureDefinition featureDefintion in _featureDefinitionProvider.GetAllFeatureDefinitionsAsync().ConfigureAwait(false))
             {
-                yield return featureDefintion?.Name;
+                yield return featureDefintion.Name;
             }
         }
 


### PR DESCRIPTION
## Why this PR?

A developer had an issue. After refresh they were getting:

> Object reference not set to an instance of an object

> at Microsoft.FeatureManagement.FeatureManager.\<GetFeatureNamesAsync>d__10.MoveNext()

 After trying to recreate the issue, I found one way. The steps are as follows:

1. Call `FeatureManager.GetFeatureNamesAsync()`.
2. Iterate the first item in the AsyncEnumerable. ( This means, `ConfigurationFeatureDefinitionProvider.GetAllFeatureDefinitionsAsync` will iterate once, meaning it will grab a list of all `IConfigurationSections` defined within FeatureManagement, but only iterate the first one )
3. Remove a flag from the Configuration
4. Refresh configuration
5. Call `IsEnabledAsync("RemovedFlag")` or iterate through a full `GetFeatureNamesAsync`. This fills the cache with "null".
6. Continue iterating the first AsyncEnumerable. 

In short- the cache gets busted when the refresh happens, but the old AsyncEnumerable is not updated. It expects the IConfigurationSection it saw before iterating to still exist. 

## Visible Changes
This fix is in two places- 
1. The `AsyncEnumerable` in `ConfigurationFeatureDefinitionProvider` will check for null iteration- since iterations can be as slow as the developer wants. If the same situation happens- there might be a null in the cache, but we won't return it.