### PR TITLE
Bug Fix - Avoid duplicated registration of TimeWindowFilter through AddFeatureFilter method

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement.FeatureFilters;
 
 namespace Microsoft.FeatureManagement
 {
@@ -25,6 +26,13 @@ namespace Microsoft.FeatureManagement
             Type serviceType = typeof(IFeatureFilterMetadata);
 
             Type implementationType = typeof(T);
+
+            //
+            // TimeWindowFilter will only be added through another overload of AddFeatureFilter 
+            if (implementationType == typeof(TimeWindowFilter))
+            {
+                return this;
+            }
 
             IEnumerable<Type> featureFilterImplementations = implementationType.GetInterfaces()
                 .Where(i => i == typeof(IFeatureFilter) || 


### PR DESCRIPTION
## Why this PR?


Bug fix #447 

## Visible change

``` C#
services.AddFeatureManagement()
            .AddFeatureFilter<TimeWindowFilter>();
```
The call of `AddFeatureFilter` on the `IFeatureManagementBuilder` returned by the `AddFeatureManagement` call will no longer register `TimeWindowFilter` repeatedly.

This PR added a check in the `AddFeatureFilter<T>()` method of the `FeatureManagementBuilder` class, if the `T` is `TimeWindowFilter`, the method will do nothing. 

All built-in feature filters are registered during the `AddFeatureManagement` call, the `TimeWindowFilter` is registered through the overload `AddFeatureFilter<T>(Func implemenetationFactory)

The `FeatureManagementBuilder` is internal and only be created in the `AddFeatureManagment` call, this ensures that AddFeatureFilter<T>()` will only be called after calling AddFeatureManagement() where the TimeWindowFilter should have been registered.


