### PR TITLE
Adjusts builder extension methods to be friendlier

### DIFF
--- a/examples/EvaluationDataToApplicationInsights/Program.cs
+++ b/examples/EvaluationDataToApplicationInsights/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddSingleton<ITelemetryInitializer, TargetingTelemetryInitializ
 // Wire up evaluation event emission
 builder.Services.AddFeatureManagement()
     .WithTargeting<HttpContextTargetingContextAccessor>()
-    .AddApplicationInsightsTelemetryPublisher();
+    .AddApplicationInsightsTelemetry();
 
 //
 // Default code from .NET template below

--- a/examples/VariantServiceDemo/Program.cs
+++ b/examples/VariantServiceDemo/Program.cs
@@ -37,7 +37,7 @@ builder.Services.AddSingleton<ICalculator, RemoteCalculator>();
 builder.Services.AddFeatureManagement()
     .WithTargeting<HttpContextTargetingContextAccessor>()
     .WithVariantService<ICalculator>("Calculator")
-    .AddApplicationInsightsTelemetryPublisher();
+    .AddApplicationInsightsTelemetry();
 
 var app = builder.Build();
 

--- a/src/Microsoft.FeatureManagement.AspNetCore/AspNetCoreFeatureManagementBuilderExtensions.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/AspNetCoreFeatureManagementBuilderExtensions.cs
@@ -78,17 +78,5 @@ namespace Microsoft.FeatureManagement
 
             return builder;
         }
-
-        /// <summary>
-        /// Adds middleware to the application's request pipeline that adds targeting information to the HTTP context.
-        /// </summary>
-        /// <param name="builder">The <see cref="IFeatureManagementBuilder"/> used to customize feature management functionality.</param>
-        /// <returns>A <see cref="IFeatureManagementBuilder"/> that can be used to customize feature management functionality.</returns>
-        public static IApplicationBuilder UseFeatureManagement(this IApplicationBuilder builder)
-        {
-            builder.UseMiddleware<TargetingHttpContextMiddleware>();
-
-            return builder;
-        }
     }
 }

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/FeatureManagementBuilderExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/FeatureManagementBuilderExtensions.cs
@@ -15,11 +15,11 @@ namespace Microsoft.FeatureManagement
     public static class FeatureManagementBuilderExtensions
     {
         /// <summary>
-        /// Adds the <see cref="ApplicationInsightsEventPublisher"/> using <see cref="ApplicationInsightsHostedService"/> to the feature management builder.
+        /// Adds the <see cref="TargetingTelemetryInitializer"/> and the <see cref="ApplicationInsightsEventPublisher"/> using <see cref="ApplicationInsightsHostedService"/> to the feature management builder.
         /// </summary>
         /// <param name="builder">The feature management builder.</param>
         /// <returns>The feature management builder.</returns>
-        public static IFeatureManagementBuilder AddApplicationInsightsTelemetryPublisher(this IFeatureManagementBuilder builder)
+        public static IFeatureManagementBuilder AddApplicationInsightsTelemetry(this IFeatureManagementBuilder builder)
         {
             if (builder == null)
             {

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/FeatureManagementBuilderExtensions.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/FeatureManagementBuilderExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.FeatureManagement.Telemetry.ApplicationInsights;
 
@@ -28,6 +30,8 @@ namespace Microsoft.FeatureManagement
             {
                 throw new ArgumentException($"The provided builder's services must not be null.", nameof(builder));
             }
+
+            builder.Services.AddSingleton<ITelemetryInitializer, TargetingTelemetryInitializer>();
 
             builder.Services.AddSingleton<ApplicationInsightsEventPublisher>();
 


### PR DESCRIPTION
Preview now with app insights telemetry looks like this:

```csharp
// Add App Insights
builder.Services.AddApplicationInsightsTelemetry(); // Shouldn't be done by us

builder.Services.AddHttpContextAccessor();

// Add FeatureManagement's TargetingTelemetryInitializer
builder.Services.AddSingleton<ITelemetryInitializer, TargetingTelemetryInitializer>();

// Add FeatureManagement
builder.Services.AddFeatureManagement()
    .WithTargeting() // Uses DefaultHttpTargetingAccessor, requires HttpContextAccessor
    .AddApplicationInsightsTelemetryPublisher();

var app = builder.Build();

//...

app.UseMiddleware<TargetingHttpContextMiddleware>();
```

Making a few opinionated changes- we can make it:

```csharp
// Add App Insights
builder.Services.AddApplicationInsightsTelemetry(); // Shouldn't be done by us

builder.Services.AddFeatureManagement()
    .WithTargeting() // Uses DefaultHttpTargetingAccessor, adds HttpContextAccessor if it's not added already
    .AddApplicationInsightsTelemetry(); // Adds TargetingTelemetryInitializer as well

var app = builder.Build();

app.UseMiddleware<TargetingHttpContextMiddleware>();
```