### PR TITLE
Remove configuration reference from variant feature flag

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -474,7 +474,6 @@ namespace Microsoft.FeatureManagement
                     {
                         Name = section[MicrosoftFeatureManagementFields.Name],
                         ConfigurationValue = section.GetSection(MicrosoftFeatureManagementFields.VariantDefinitionConfigurationValue),
-                        ConfigurationReference = section[MicrosoftFeatureManagementFields.VariantDefinitionConfigurationReference],
                         StatusOverride = statusOverride
                     };
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -105,11 +105,6 @@ namespace Microsoft.FeatureManagement
         public ILogger Logger { get; set; }
 
         /// <summary>
-        /// The configuration reference for feature variants.
-        /// </summary>
-        public IConfiguration Configuration { get; set; }
-
-        /// <summary>
         /// The targeting context accessor for feature variant allocation.
         /// </summary>
         public ITargetingContextAccessor TargetingContextAccessor { get; set; }
@@ -855,19 +850,6 @@ namespace Microsoft.FeatureManagement
             if (variantDefinition.ConfigurationValue.Exists())
             {
                 variantConfiguration = variantDefinition.ConfigurationValue;
-            }
-            else if (!string.IsNullOrEmpty(variantDefinition.ConfigurationReference))
-            {
-                if (Configuration == null)
-                {
-                    Logger?.LogWarning($"Cannot use {nameof(variantDefinition.ConfigurationReference)} as no instance of {nameof(IConfiguration)} is present.");
-
-                    return null;
-                }
-                else
-                {
-                    variantConfiguration = Configuration.GetSection(variantDefinition.ConfigurationReference);
-                }
             }
 
             return new Variant()

--- a/src/Microsoft.FeatureManagement/MicrosoftFeatureManagementFields.cs
+++ b/src/Microsoft.FeatureManagement/MicrosoftFeatureManagementFields.cs
@@ -42,7 +42,6 @@ namespace Microsoft.FeatureManagement
         // Variants keywords
         public const string VariantsSectionName = "variants";
         public const string VariantDefinitionConfigurationValue = "configuration_value";
-        public const string VariantDefinitionConfigurationReference = "configuration_reference";
         public const string VariantDefinitionStatusOverride = "status_override";
 
         // Telemetry keywords

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -50,7 +50,6 @@ namespace Microsoft.FeatureManagement
                 SessionManagers = sp.GetRequiredService<IEnumerable<ISessionManager>>(),
                 Cache = sp.GetRequiredService<IMemoryCache>(),
                 Logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<FeatureManager>(),
-                Configuration = sp.GetService<IConfiguration>(),
                 TargetingContextAccessor = sp.GetService<ITargetingContextAccessor>(),
                 AssignerOptions = sp.GetRequiredService<IOptions<TargetingEvaluationOptions>>().Value
             });
@@ -137,7 +136,6 @@ namespace Microsoft.FeatureManagement
                 SessionManagers = sp.GetRequiredService<IEnumerable<ISessionManager>>(),
                 Cache = sp.GetRequiredService<IMemoryCache>(),
                 Logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<FeatureManager>(),
-                Configuration = sp.GetService<IConfiguration>(),
                 TargetingContextAccessor = sp.GetService<ITargetingContextAccessor>(),
                 AssignerOptions = sp.GetRequiredService<IOptions<TargetingEvaluationOptions>>().Value
             });

--- a/src/Microsoft.FeatureManagement/VariantDefinition.cs
+++ b/src/Microsoft.FeatureManagement/VariantDefinition.cs
@@ -22,11 +22,6 @@ namespace Microsoft.FeatureManagement
         public IConfigurationSection ConfigurationValue { get; set; }
 
         /// <summary>
-        /// A reference pointing to the configuration for this variant of the feature.
-        /// </summary>
-        public string ConfigurationReference { get; set; }
-
-        /// <summary>
         /// Overrides the state of the feature if this variant has been assigned.
         /// </summary>
         public StatusOverride StatusOverride { get; set; } = StatusOverride.None;

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1472,7 +1472,6 @@ namespace Tests.FeatureManagement
             Variant variant = await featureManager.GetVariantAsync(Features.VariantFeaturePercentileOn, cancellationToken);
 
             Assert.Equal("Big", variant.Name);
-            Assert.Equal("green", variant.Configuration["Color"]);
             Assert.False(await featureManager.IsEnabledAsync(Features.VariantFeaturePercentileOn, cancellationToken));
 
             variant = await featureManager.GetVariantAsync(Features.VariantFeaturePercentileOff, cancellationToken);
@@ -1540,11 +1539,6 @@ namespace Tests.FeatureManagement
             variant = await featureManager.GetVariantAsync(Features.VariantFeatureNoAllocation, cancellationToken);
 
             Assert.Null(variant);
-
-            // Verify that ConfigurationValue has priority over ConfigurationReference
-            variant = await featureManager.GetVariantAsync(Features.VariantFeatureBothConfigurations, cancellationToken);
-
-            Assert.Equal("600px", variant.Configuration.Value);
 
             // Verify that an exception is thrown for invalid StatusOverride value
             FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(async () =>

--- a/tests/Tests.FeatureManagement/Features.cs
+++ b/tests/Tests.FeatureManagement/Features.cs
@@ -24,7 +24,6 @@ namespace Tests.FeatureManagement
         public const string VariantFeatureNoVariants = "VariantFeatureNoVariants";
         public const string VariantFeatureNoAllocation = "VariantFeatureNoAllocation";
         public const string VariantFeatureAlwaysOffNoAllocation = "VariantFeatureAlwaysOffNoAllocation";
-        public const string VariantFeatureBothConfigurations = "VariantFeatureBothConfigurations";
         public const string VariantFeatureInvalidStatusOverride = "VariantFeatureInvalidStatusOverride";
         public const string VariantFeatureInvalidFromTo = "VariantFeatureInvalidFromTo";
         public const string VariantImplementationFeature = "VariantImplementationFeature";

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -6,17 +6,6 @@
   },
   "AllowedHosts": "*",
 
-  "ShoppingCart": {
-    "Big": {
-      "Size": 600,
-      "Color": "green"
-    },
-    "Small": {
-      "Size": 300,
-      "Color": "gray"
-    }
-  },
-
   "feature_management": {
     "feature_flags": [
       {
@@ -209,7 +198,6 @@
         "variants": [
           {
             "name": "Big",
-            "configuration_reference": "ShoppingCart:Big",
             "status_override": "Disabled"
           }
         ],
@@ -232,8 +220,7 @@
         "enabled": true,
         "variants": [
           {
-            "name": "Big",
-            "configuration_reference": "ShoppingCart:Big"
+            "name": "Big"
           }
         ],
         "allocation": {
@@ -255,8 +242,7 @@
         "enabled": false,
         "variants": [
           {
-            "name": "Big",
-            "configuration_reference": "ShoppingCart:Big"
+            "name": "Big"
           }
         ],
         "allocation": {
@@ -408,20 +394,6 @@
         ],
         "telemetry": {
           "enabled": true
-        }
-      },
-      {
-        "id": "VariantFeatureBothConfigurations",
-        "enabled": true,
-        "variants": [
-          {
-            "name": "Small",
-            "configuration_value": "600px",
-            "configuration_reference": "ShoppingCart:Small"
-          }
-        ],
-        "allocation": {
-          "default_when_enabled": "Small"
         }
       },
       {


### PR DESCRIPTION
## Why this PR?

#489 

## Visible changes

`configuration_reference` is not longer supported.