### PR TITLE
Last one wins flag providers

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.FeatureManagement
             IEnumerable<IConfigurationSection> dotnetFeatureDefinitionSections = GetDotnetFeatureDefinitionSections();
 
             IConfigurationSection configuration = dotnetFeatureDefinitionSections
-                .LastOrDefault(section =>
+                .FirstOrDefault(section =>
                     string.Equals(section.Key, featureName, StringComparison.OrdinalIgnoreCase));
 
             if (configuration == null)

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.FeatureManagement
             IEnumerable<IConfigurationSection> dotnetFeatureDefinitionSections = GetDotnetFeatureDefinitionSections();
 
             IConfigurationSection configuration = dotnetFeatureDefinitionSections
-                .FirstOrDefault(section =>
+                .LastOrDefault(section =>
                     string.Equals(section.Key, featureName, StringComparison.OrdinalIgnoreCase));
 
             if (configuration == null)
@@ -172,7 +172,7 @@ namespace Microsoft.FeatureManagement
             IEnumerable<IConfigurationSection> microsoftFeatureDefinitionSections = GetMicrosoftFeatureDefinitionSections();
 
             IConfigurationSection configuration = microsoftFeatureDefinitionSections
-                .FirstOrDefault(section =>
+                .LastOrDefault(section =>
                     string.Equals(section[MicrosoftFeatureManagementFields.Id], featureName, StringComparison.OrdinalIgnoreCase));
 
             if (configuration == null)

--- a/tests/Tests.FeatureManagement/DotnetFeatureManagementSchema.json
+++ b/tests/Tests.FeatureManagement/DotnetFeatureManagementSchema.json
@@ -11,6 +11,7 @@
           }
         }
       ]
-    }
+    },
+    "DuplicateFeature": false
   }
 }

--- a/tests/Tests.FeatureManagement/DotnetFeatureManagementSchema.json
+++ b/tests/Tests.FeatureManagement/DotnetFeatureManagementSchema.json
@@ -11,7 +11,6 @@
           }
         }
       ]
-    },
-    "DuplicateFeature": false
+    }
   }
 }

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -427,6 +427,26 @@ namespace Tests.FeatureManagement
 
             Assert.True(called);
         }
+
+        [Fact]
+        public async Task LastFeatureFlagWins()
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            IServiceCollection services = new ServiceCollection();
+
+            services
+                .AddSingleton(configuration)
+                .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync(Features.DuplicateFlag));
+        }
     }
 
     public class FeatureManagementFeatureFilterGeneralTest

--- a/tests/Tests.FeatureManagement/Features.cs
+++ b/tests/Tests.FeatureManagement/Features.cs
@@ -30,5 +30,6 @@ namespace Tests.FeatureManagement
         public const string OnTelemetryTestFeature = "OnTelemetryTestFeature";
         public const string OffTelemetryTestFeature = "OffTelemetryTestFeature";
         public const string ContextualFeatureWithVariant = "ContextualFeatureWithVariant";
+        public const string DuplicateFlag = "DuplicateFlag";
     }
 }

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -530,6 +530,14 @@
           "default_when_enabled": "Big",
           "default_when_disabled": "Small"
         }
+      },
+      {
+        "id": "DuplicateFlag",
+        "enabled": false
+      },
+      {
+        "id": "DuplicateFlag",
+        "enabled": true
       }
     ]
   }


### PR DESCRIPTION
## Why this PR?

Updates the flag provider to handle duplicate flags by using the last flag instead of the first. 

## Visible Changes

* For the [Microsoft Feature Flag Schema](https://github.com/microsoft/FeatureManagement/blob/main/Schema/FeatureManagement.v2.0.0.schema.json) - When there are duplicate feature flag ids- the last flag will be used. This allows multiple flag providers or multiple sources to load flags in a consistent way across languages. 
  * This also aligns with the existing functionality in stable. 
  * This change only affects the built-in `ConfigurationFeatureDefinitionProvider`, custom providers are still in charge of their ordering. 