### PR TITLE
Resolves snapshot breaking change and adjusts feature tag helper as well

### DIFF
--- a/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
@@ -14,7 +14,8 @@ namespace Microsoft.FeatureManagement.Mvc.TagHelpers
     /// </summary>
     public class FeatureTagHelper : TagHelper
     {
-        private readonly IVariantFeatureManager _featureManager;
+        private readonly IFeatureManager _featureManager;
+        private readonly IVariantFeatureManager _variantFeatureManager;
 
         /// <summary>
         /// A feature name, or comma separated list of feature names, for which the content should be rendered. By default, all specified features must be enabled to render the content, but this requirement can be controlled by the <see cref="Requirement"/> property.
@@ -38,12 +39,14 @@ namespace Microsoft.FeatureManagement.Mvc.TagHelpers
         public string Variant { get; set; }
 
         /// <summary>
-        /// Creates a feature tag helper.
+        /// Creates a feature tag helper. Takes both a feature manager and a variant feature manager for backwards compatibility.
         /// </summary>
         /// <param name="featureManager">The feature manager snapshot to use to evaluate feature state.</param>
-        public FeatureTagHelper(IVariantFeatureManagerSnapshot featureManager)
+        /// <param name="variantFeatureManager">The variant feature manager snapshot to use to evaluate feature state.</param>
+        public FeatureTagHelper(IFeatureManagerSnapshot featureManager, IVariantFeatureManagerSnapshot variantFeatureManager)
         {
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
+            _variantFeatureManager = variantFeatureManager ?? throw new ArgumentNullException(nameof(variantFeatureManager));
         }
 
         /// <summary>
@@ -84,7 +87,7 @@ namespace Microsoft.FeatureManagement.Mvc.TagHelpers
                     enabled = await variants.Any(
                         async variant =>
                         {
-                            Variant assignedVariant = await _featureManager.GetVariantAsync(features.First()).ConfigureAwait(false);
+                            Variant assignedVariant = await _variantFeatureManager.GetVariantAsync(features.First()).ConfigureAwait(false);
 
                             return variant == assignedVariant?.Name;
                         });

--- a/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TagHelpers/FeatureTagHelper.cs
@@ -39,12 +39,13 @@ namespace Microsoft.FeatureManagement.Mvc.TagHelpers
         public string Variant { get; set; }
 
         /// <summary>
-        /// Creates a feature tag helper. Takes both a feature manager and a variant feature manager for backwards compatibility.
+        /// Creates a feature tag helper.
         /// </summary>
         /// <param name="featureManager">The feature manager snapshot to use to evaluate feature state.</param>
         /// <param name="variantFeatureManager">The variant feature manager snapshot to use to evaluate feature state.</param>
         public FeatureTagHelper(IFeatureManagerSnapshot featureManager, IVariantFeatureManagerSnapshot variantFeatureManager)
         {
+            // Takes both a feature manager and a variant feature manager for backwards compatibility.
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
             _variantFeatureManager = variantFeatureManager ?? throw new ArgumentNullException(nameof(variantFeatureManager));
         }

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -18,8 +18,7 @@ namespace Microsoft.FeatureManagement
     {
         private readonly IFeatureManager _featureManager;
         private readonly IVariantFeatureManager _variantFeatureManager;
-        private readonly ConcurrentDictionary<string, Task<bool>> _flagCache = new ConcurrentDictionary<string, Task<bool>>();
-        private readonly ConcurrentDictionary<string, ValueTask<bool>> _variantFlagCache = new ConcurrentDictionary<string, ValueTask<bool>>();
+        private readonly ConcurrentDictionary<string, ValueTask<bool>> _flagCache = new ConcurrentDictionary<string, ValueTask<bool>>();
         private readonly ConcurrentDictionary<string, Variant> _variantCache = new ConcurrentDictionary<string, Variant>();
         private IEnumerable<string> _featureNames;
 
@@ -74,26 +73,26 @@ namespace Microsoft.FeatureManagement
         {
             return _flagCache.GetOrAdd(
                 feature,
-                (key) => _featureManager.IsEnabledAsync(key));
+                (key) => new ValueTask<bool>(_featureManager.IsEnabledAsync(key))).AsTask();
         }
 
         public Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
         {
             return _flagCache.GetOrAdd(
                 feature,
-                (key) => _featureManager.IsEnabledAsync(key, context));
+                (key) => new ValueTask<bool>(_featureManager.IsEnabledAsync(key, context))).AsTask();
         }
 
         public ValueTask<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken)
         {
-            return _variantFlagCache.GetOrAdd(
+            return _flagCache.GetOrAdd(
                 feature,
                 (key) => _variantFeatureManager.IsEnabledAsync(key, cancellationToken));
         }
 
         public ValueTask<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken)
         {
-            return _variantFlagCache.GetOrAdd(
+            return _flagCache.GetOrAdd(
                 feature,
                 (key) => _variantFeatureManager.IsEnabledAsync(key, context, cancellationToken));
         }

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -16,19 +16,38 @@ namespace Microsoft.FeatureManagement
     /// </summary>
     class FeatureManagerSnapshot : IFeatureManagerSnapshot, IVariantFeatureManagerSnapshot
     {
-        private readonly IVariantFeatureManager _featureManager;
-        private readonly ConcurrentDictionary<string, ValueTask<bool>> _flagCache = new ConcurrentDictionary<string, ValueTask<bool>>();
+        private readonly IFeatureManager _featureManager;
+        private readonly IVariantFeatureManager _variantFeatureManager;
+        private readonly ConcurrentDictionary<string, Task<bool>> _flagCache = new ConcurrentDictionary<string, Task<bool>>();
+        private readonly ConcurrentDictionary<string, ValueTask<bool>> _variantFlagCache = new ConcurrentDictionary<string, ValueTask<bool>>();
         private readonly ConcurrentDictionary<string, Variant> _variantCache = new ConcurrentDictionary<string, Variant>();
         private IEnumerable<string> _featureNames;
 
-        public FeatureManagerSnapshot(IVariantFeatureManager featureManager)
+        // Takes both a feature manager and a variant feature manager for backwards compatibility.
+        public FeatureManagerSnapshot(IFeatureManager featureManager, IVariantFeatureManager variantFeatureManager)
         {
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
+            _variantFeatureManager = variantFeatureManager ?? throw new ArgumentNullException(nameof(variantFeatureManager));
         }
 
-        public IAsyncEnumerable<string> GetFeatureNamesAsync()
+        public async IAsyncEnumerable<string> GetFeatureNamesAsync()
         {
-            return GetFeatureNamesAsync(CancellationToken.None);
+            if (_featureNames == null)
+            {
+                var featureNames = new List<string>();
+
+                await foreach (string featureName in _featureManager.GetFeatureNamesAsync().ConfigureAwait(false))
+                {
+                    featureNames.Add(featureName);
+                }
+
+                _featureNames = featureNames;
+            }
+
+            foreach (string featureName in _featureNames)
+            {
+                yield return featureName;
+            }
         }
 
         public async IAsyncEnumerable<string> GetFeatureNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
@@ -37,7 +56,7 @@ namespace Microsoft.FeatureManagement
             {
                 var featureNames = new List<string>();
 
-                await foreach (string featureName in _featureManager.GetFeatureNamesAsync(cancellationToken).ConfigureAwait(false))
+                await foreach (string featureName in _variantFeatureManager.GetFeatureNamesAsync(cancellationToken).ConfigureAwait(false))
                 {
                     featureNames.Add(featureName);
                 }
@@ -55,28 +74,28 @@ namespace Microsoft.FeatureManagement
         {
             return _flagCache.GetOrAdd(
                 feature,
-                (key) => _featureManager.IsEnabledAsync(key, CancellationToken.None)).AsTask();
+                (key) => _featureManager.IsEnabledAsync(key));
         }
 
         public Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
         {
             return _flagCache.GetOrAdd(
                 feature,
-                (key) => _featureManager.IsEnabledAsync(key, context, CancellationToken.None)).AsTask();
+                (key) => _featureManager.IsEnabledAsync(key, context));
         }
 
         public ValueTask<bool> IsEnabledAsync(string feature, CancellationToken cancellationToken)
         {
-            return _flagCache.GetOrAdd(
+            return _variantFlagCache.GetOrAdd(
                 feature,
-                (key) => _featureManager.IsEnabledAsync(key, cancellationToken));
+                (key) => _variantFeatureManager.IsEnabledAsync(key, cancellationToken));
         }
 
         public ValueTask<bool> IsEnabledAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken)
         {
-            return _flagCache.GetOrAdd(
+            return _variantFlagCache.GetOrAdd(
                 feature,
-                (key) => _featureManager.IsEnabledAsync(key, context, cancellationToken));
+                (key) => _variantFeatureManager.IsEnabledAsync(key, context, cancellationToken));
         }
 
         public async ValueTask<Variant> GetVariantAsync(string feature, CancellationToken cancellationToken)
@@ -90,7 +109,7 @@ namespace Microsoft.FeatureManagement
                 return _variantCache[cacheKey];
             }
 
-            Variant variant = await _featureManager.GetVariantAsync(feature, cancellationToken).ConfigureAwait(false);
+            Variant variant = await _variantFeatureManager.GetVariantAsync(feature, cancellationToken).ConfigureAwait(false);
 
             _variantCache[cacheKey] = variant;
 
@@ -108,7 +127,7 @@ namespace Microsoft.FeatureManagement
                 return _variantCache[cacheKey];
             }
 
-            Variant variant = await _featureManager.GetVariantAsync(feature, context, cancellationToken).ConfigureAwait(false);
+            Variant variant = await _variantFeatureManager.GetVariantAsync(feature, context, cancellationToken).ConfigureAwait(false);
 
             _variantCache[cacheKey] = variant;
 

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -34,13 +34,7 @@ namespace Microsoft.FeatureManagement
                     "Scoped feature management has been registered.");
             }
 
-            services.AddLogging();
-
-            services.AddMemoryCache();
-
-            //
-            // Add required services
-            services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
+            AddCommonFeatureManagementServices(services);
 
             services.AddSingleton(sp => new FeatureManager(
                             sp.GetRequiredService<IFeatureDefinitionProvider>(),
@@ -58,27 +52,7 @@ namespace Microsoft.FeatureManagement
 
             services.TryAddSingleton<IVariantFeatureManager>(sp => sp.GetRequiredService<FeatureManager>());
 
-            services.AddScoped<FeatureManagerSnapshot>();
-
-            services.TryAddScoped<IFeatureManagerSnapshot>(sp => sp.GetRequiredService<FeatureManagerSnapshot>());
-
-            services.TryAddScoped<IVariantFeatureManagerSnapshot>(sp => sp.GetRequiredService<FeatureManagerSnapshot>());
-
-            var builder = new FeatureManagementBuilder(services);
-
-            //
-            // Add built-in feature filters
-            builder.AddFeatureFilter<PercentageFilter>();
-
-            builder.AddFeatureFilter<TimeWindowFilter>(sp =>
-                new TimeWindowFilter()
-                {
-                    Cache = sp.GetRequiredService<IMemoryCache>()
-                });
-
-            builder.AddFeatureFilter<ContextualTargetingFilter>();
-
-            return builder;
+            return GetFeatureManagementBuilder(services);
         }
 
         /// <summary>
@@ -120,13 +94,7 @@ namespace Microsoft.FeatureManagement
                     "Singleton feature management has been registered.");
             }
 
-            services.AddLogging();
-
-            services.AddMemoryCache();
-
-            //
-            // Add required services
-            services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
+            AddCommonFeatureManagementServices(services);
 
             services.AddScoped(sp => new FeatureManager(
                             sp.GetRequiredService<IFeatureDefinitionProvider>(),
@@ -144,27 +112,7 @@ namespace Microsoft.FeatureManagement
 
             services.TryAddScoped<IVariantFeatureManager>(sp => sp.GetRequiredService<FeatureManager>());
 
-            services.AddScoped<FeatureManagerSnapshot>();
-
-            services.TryAddScoped<IFeatureManagerSnapshot>(sp => sp.GetRequiredService<FeatureManagerSnapshot>());
-
-            services.TryAddScoped<IVariantFeatureManagerSnapshot>(sp => sp.GetRequiredService<FeatureManagerSnapshot>());
-
-            var builder = new FeatureManagementBuilder(services);
-
-            //
-            // Add built-in feature filters
-            builder.AddFeatureFilter<PercentageFilter>();
-
-            builder.AddFeatureFilter<TimeWindowFilter>(sp =>
-                new TimeWindowFilter()
-                {
-                    Cache = sp.GetRequiredService<IMemoryCache>()
-                });
-
-            builder.AddFeatureFilter<ContextualTargetingFilter>();
-
-            return builder;
+            return GetFeatureManagementBuilder(services);
         }
 
         /// <summary>
@@ -189,6 +137,40 @@ namespace Microsoft.FeatureManagement
                 });
 
             return services.AddScopedFeatureManagement();
+        }
+
+        private static void AddCommonFeatureManagementServices(IServiceCollection services)
+        {
+            services.AddLogging();
+
+            services.AddMemoryCache();
+
+            services.TryAddSingleton<IFeatureDefinitionProvider, ConfigurationFeatureDefinitionProvider>();
+
+            services.AddScoped<FeatureManagerSnapshot>();
+
+            services.TryAddScoped<IFeatureManagerSnapshot>(sp => sp.GetRequiredService<FeatureManagerSnapshot>());
+
+            services.TryAddScoped<IVariantFeatureManagerSnapshot>(sp => sp.GetRequiredService<FeatureManagerSnapshot>());
+        }
+
+        private static IFeatureManagementBuilder GetFeatureManagementBuilder(IServiceCollection services)
+        {
+            var builder = new FeatureManagementBuilder(services);
+
+            //
+            // Add built-in feature filters
+            builder.AddFeatureFilter<PercentageFilter>();
+
+            builder.AddFeatureFilter<TimeWindowFilter>(sp =>
+                new TimeWindowFilter()
+                {
+                    Cache = sp.GetRequiredService<IMemoryCache>()
+                });
+
+            builder.AddFeatureFilter<ContextualTargetingFilter>();
+
+            return builder;
         }
     }
 }

--- a/tests/Tests.FeatureManagement.AspNetCore/Tests.FeatureManagement.AspNetCore.csproj
+++ b/tests/Tests.FeatureManagement.AspNetCore/Tests.FeatureManagement.AspNetCore.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -376,59 +376,6 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task CustomFeatureDefinitionProvider()
-        {
-            FeatureDefinition testFeature = new FeatureDefinition
-            {
-                Name = Features.ConditionalFeature,
-                EnabledFor = new List<FeatureFilterConfiguration>()
-                {
-                    new FeatureFilterConfiguration
-                    {
-                        Name = "Test",
-                        Parameters = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
-                        {
-                           { "P1", "V1" },
-                        }).Build()
-                    }
-                }
-            };
-
-            var services = new ServiceCollection();
-
-            services.AddSingleton<IFeatureDefinitionProvider>(new InMemoryFeatureDefinitionProvider(new FeatureDefinition[] { testFeature }))
-                    .AddFeatureManagement()
-                    .AddFeatureFilter<TestFilter>();
-
-            ServiceProvider serviceProvider = services.BuildServiceProvider();
-
-            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
-
-            IEnumerable<IFeatureFilterMetadata> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
-
-            //
-            // Sync filter
-            TestFilter testFeatureFilter = (TestFilter)featureFilters.First(f => f is TestFilter);
-
-            bool called = false;
-
-            testFeatureFilter.Callback = (evaluationContext) =>
-            {
-                called = true;
-
-                Assert.Equal("V1", evaluationContext.Parameters["P1"]);
-
-                Assert.Equal(Features.ConditionalFeature, evaluationContext.FeatureName);
-
-                return Task.FromResult(true);
-            };
-
-            await featureManager.IsEnabledAsync(Features.ConditionalFeature);
-
-            Assert.True(called);
-        }
-
-        [Fact]
         public async Task LastFeatureFlagWins()
         {
             IConfiguration configuration = new ConfigurationBuilder()
@@ -1916,6 +1863,117 @@ namespace Tests.FeatureManagement
             bool result = await featureManager.IsEnabledAsync(Features.OnTestFeature, cancellationToken);
 
             Assert.True(result);
+        }
+    }
+
+    public class CustomImplementationsFeatureManagementTests
+    {
+        public class CustomIFeatureManager : IFeatureManager
+        {
+            public IAsyncEnumerable<string> GetFeatureNamesAsync()
+            {
+                return new string[1] { "Test" }.ToAsyncEnumerable();
+            }
+
+            public async Task<bool> IsEnabledAsync(string feature)
+            {
+                return await Task.FromResult(feature == "Test");
+            }
+
+            public async Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
+            {
+                return await Task.FromResult(feature == "Test");
+            }
+        }
+
+        [Fact]
+        public async Task CustomIFeatureManagerTest()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var services = new ServiceCollection();
+
+            services.AddSingleton(config)
+                    .AddSingleton<IFeatureManager, CustomIFeatureManager>()
+                    .AddFeatureManagement(); // Shouldn't override
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync("Test"));
+            Assert.False(await featureManager.IsEnabledAsync("NotTest"));
+
+            // Provider shouldn't be affected
+            IFeatureDefinitionProvider featureDefinitionProvider = serviceProvider.GetRequiredService<IFeatureDefinitionProvider>();
+
+            Assert.True(await featureDefinitionProvider.GetAllFeatureDefinitionsAsync().AnyAsync());
+            Assert.NotNull(await featureDefinitionProvider.GetFeatureDefinitionAsync("OnTestFeature"));
+
+            // Snapshot should use available IFeatureManager
+            FeatureManagerSnapshot featureManagerSnapshot = serviceProvider.GetRequiredService<FeatureManagerSnapshot>();
+
+            Assert.True(await featureManagerSnapshot.IsEnabledAsync("Test"));
+            Assert.False(await featureManagerSnapshot.IsEnabledAsync("NotTest"));
+            Assert.False(await featureManagerSnapshot.IsEnabledAsync("OnTestFeature"));
+
+            // But use IVariantFeatureManager when using new interface
+            Assert.False(await featureManagerSnapshot.IsEnabledAsync("Test", CancellationToken.None));
+            Assert.False(await featureManagerSnapshot.IsEnabledAsync("NotTest", CancellationToken.None));
+            Assert.True(await featureManagerSnapshot.IsEnabledAsync("OnTestFeature", CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task CustomIFeatureDefinitionProvider()
+        {
+            FeatureDefinition testFeature = new FeatureDefinition
+            {
+                Name = Features.ConditionalFeature,
+                EnabledFor = new List<FeatureFilterConfiguration>()
+                {
+                    new FeatureFilterConfiguration
+                    {
+                        Name = "Test",
+                        Parameters = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
+                        {
+                           { "P1", "V1" },
+                        }).Build()
+                    }
+                }
+            };
+
+            var services = new ServiceCollection();
+
+            services.AddSingleton<IFeatureDefinitionProvider>(new InMemoryFeatureDefinitionProvider(new FeatureDefinition[] { testFeature }))
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<TestFilter>();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            IEnumerable<IFeatureFilterMetadata> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
+
+            //
+            // Sync filter
+            TestFilter testFeatureFilter = (TestFilter)featureFilters.First(f => f is TestFilter);
+
+            bool called = false;
+
+            testFeatureFilter.Callback = (evaluationContext) =>
+            {
+                called = true;
+
+                Assert.Equal("V1", evaluationContext.Parameters["P1"]);
+
+                Assert.Equal(Features.ConditionalFeature, evaluationContext.FeatureName);
+
+                return Task.FromResult(true);
+            };
+
+            await featureManager.IsEnabledAsync(Features.ConditionalFeature);
+
+            Assert.True(called);
         }
     }
 }

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1917,10 +1917,10 @@ namespace Tests.FeatureManagement
             Assert.False(await featureManagerSnapshot.IsEnabledAsync("NotTest"));
             Assert.False(await featureManagerSnapshot.IsEnabledAsync("OnTestFeature"));
 
-            // But use IVariantFeatureManager when using new interface
-            Assert.False(await featureManagerSnapshot.IsEnabledAsync("Test", CancellationToken.None));
+            // Use snapshot results even though IVariantFeatureManager would be called here
+            Assert.True(await featureManagerSnapshot.IsEnabledAsync("Test", CancellationToken.None));
             Assert.False(await featureManagerSnapshot.IsEnabledAsync("NotTest", CancellationToken.None));
-            Assert.True(await featureManagerSnapshot.IsEnabledAsync("OnTestFeature", CancellationToken.None));
+            Assert.False(await featureManagerSnapshot.IsEnabledAsync("OnTestFeature", CancellationToken.None));
         }
 
         [Fact]

--- a/tests/Tests.FeatureManagement/Tests.FeatureManagement.csproj
+++ b/tests/Tests.FeatureManagement/Tests.FeatureManagement.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## Why this PR?

* Resolves breaking change with `IFeatureManagerSnapshot` brought up by https://github.com/microsoft/FeatureManagement-Dotnet/issues/117#issuecomment-2369011536
* More unit tests to catch similar issues in the future. 

## Visible Changes

* `IFeatureManagerSnapshot` and `FeatureTagHelper` now require both an `IFeatureManager` and an `IVariantFeatureManager`. For the common case, these will refer to the same instance. By separating them, we preserve backwards compatability for custom `IFeatureManager` implementations. 
