### PR TITLE
[WIP] add variant allocation context option

### DIFF
--- a/src/Microsoft.FeatureManagement/Allocation/Allocation.cs
+++ b/src/Microsoft.FeatureManagement/Allocation/Allocation.cs
@@ -36,6 +36,11 @@ namespace Microsoft.FeatureManagement
         public IEnumerable<PercentileAllocation> Percentile { get; set; }
 
         /// <summary>
+        /// Describes a mapping of contextual filters to variants.
+        /// </summary>
+        public IEnumerable<ContextualFilterAllocation> AllocatedFor { get; set; }
+
+        /// <summary>
         /// Maps users to the same percentile across multiple feature flags.
         /// </summary>
         public string Seed { get; set; }

--- a/src/Microsoft.FeatureManagement/Allocation/ContextualFilterAllocation.cs
+++ b/src/Microsoft.FeatureManagement/Allocation/ContextualFilterAllocation.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// The definition of a filter allocation.
+    /// </summary>
+    public class ContextualFilterAllocation : FeatureFilterConfiguration
+    {
+        /// <summary>
+        /// The name of the variant.
+        /// </summary>
+        public string Variant { get; set; }
+    }
+}

--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -451,6 +451,15 @@ namespace Microsoft.FeatureManagement
                             To = to
                         };
                     }),
+                    AllocatedFor = allocationSection.GetSection(MicrosoftFeatureManagementFields.ClientFilters).GetChildren().Select(filterAllocation =>
+                    {
+                        return new ContextualFilterAllocation()
+                        {
+                            Name = filterAllocation[MicrosoftFeatureManagementFields.Name],
+                            Parameters = new ConfigurationWrapper(filterAllocation.GetSection(MicrosoftFeatureManagementFields.Parameters)),
+                            Variant = filterAllocation[MicrosoftFeatureManagementFields.AllocationVariantKeyword]
+                        };
+                    }),
                     Seed = allocationSection[MicrosoftFeatureManagementFields.AllocationSeed]
                 };
             }

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -97,7 +97,7 @@ namespace Microsoft.FeatureManagement
             return variant;
         }
 
-        public async ValueTask<Variant> GetVariantAsync(string feature, ITargetingContext context, CancellationToken cancellationToken)
+        public async ValueTask<Variant> GetVariantAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken)
         {
             string cacheKey = GetVariantCacheKey(feature);
 

--- a/src/Microsoft.FeatureManagement/IVariantFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IVariantFeatureManager.cs
@@ -52,6 +52,6 @@ namespace Microsoft.FeatureManagement
         /// <param name="context">A context that provides information to evaluate which variant will be assigned to the user.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A variant assigned to the user based on the feature's configured allocation.</returns>
-        ValueTask<Variant> GetVariantAsync(string feature, ITargetingContext context, CancellationToken cancellationToken = default);
+        ValueTask<Variant> GetVariantAsync<TContext>(string feature, TContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.FeatureManagement/MicrosoftFeatureManagementFields.cs
+++ b/src/Microsoft.FeatureManagement/MicrosoftFeatureManagementFields.cs
@@ -32,6 +32,7 @@ namespace Microsoft.FeatureManagement
         public const string PercentileAllocationSectionName = "percentile";
         public const string PercentileAllocationFrom = "from";
         public const string PercentileAllocationTo = "to";
+        public const string FilterAllocationSectionName = ClientFilters;
         public const string AllocationSeed = "seed";
 
         //

--- a/src/Microsoft.FeatureManagement/Telemetry/VariantAssignmentReason.cs
+++ b/src/Microsoft.FeatureManagement/Telemetry/VariantAssignmentReason.cs
@@ -36,6 +36,11 @@ namespace Microsoft.FeatureManagement.Telemetry
         /// <summary>
         /// The variant is assigned because of the percentile allocation when a feature flag is enabled.
         /// </summary>
-        Percentile
+        Percentile,
+
+        /// <summary>
+        /// The variant is assigned because of a matching filter.
+        /// </summary>
+        Filter
     }
 }


### PR DESCRIPTION
This is quick and dirty, but I needed it for a POC project and thought getting it some attention would be helpful. I still need to add unit tests. Resolves #460. 

Usage:
```json
{
  "id": "TestVariant",
  "enabled": true,
  "allocation": {
    "default_when_enabled": "Default",
    "client_filters": [
      {
        "name": "TestFilter",
        "variant": "V1",
        "parameters": {
          "SomeParam": "SomeValue"
        }
      },
      {
        "name": "TestFilter",
        "variant": "V2",
        "parameters": {
          "SomeParam": "SomeValue2"
        }
      }
    ]
  },
  "variants": [
    {
      "name": "Default",
      "configuration_value": "Default"
    },
    {
      "name": "V1",
      "configuration_value": "Variant 1"
    },
    {
      "name": "V2",
      "configuration_value": "Variant 2"
    }
  ]
}
```

```csharp
var test = await variantFeatureManager.GetVariantAsync("TestVariant", new TestFilterContext { SomeParam = "SomeValue" }); 
// test.Configuration.Value == "Variant 1"
```