### PR TITLE
Small fix for recurring time window testcase

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceEvaluator.cs
@@ -347,7 +347,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// </summary>
         private static List<DayOfWeek> SortDaysOfWeek(IEnumerable<DayOfWeek> daysOfWeek, DayOfWeek firstDayOfWeek)
         {
-            List<DayOfWeek> result = daysOfWeek.ToList();
+            List<DayOfWeek> result = daysOfWeek.Distinct().ToList(); // dedup
 
             result.Sort((x, y) =>
                 CalculateWeeklyDayOffset(x, firstDayOfWeek)

--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
@@ -381,7 +381,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 DateTime firstDayOfNextWeek = firstDayOfThisWeek.AddDays(DaysPerWeek);
 
                 DateTime firstOccurrenceInNextWeek = firstDayOfNextWeek.AddDays(
-                    CalculateWeeklyDayOffset(sortedDaysOfWeek.First(), firstDayOfWeek));
+                    CalculateWeeklyDayOffset(sortedDaysOfWeek.First(), firstDayOfWeek)); // firstDayOfWeek may not in the sortedDaysOfWeek
 
                 TimeSpan gap = firstOccurrenceInNextWeek - prev;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
@@ -341,6 +341,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         private static bool IsDurationCompliantWithDaysOfWeek(TimeSpan duration, int interval, IEnumerable<DayOfWeek> daysOfWeek, DayOfWeek firstDayOfWeek)
         {
             Debug.Assert(interval > 0);
+            Debug.Assert(daysOfWeek.Count() > 0);
 
             if (daysOfWeek.Count() == 1)
             {
@@ -351,35 +352,27 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             DayOfWeek firstDay = sortedDaysOfWeek.First(); // the closest occurrence day to the first day of week
 
-            DateTime firstOccurrenceOfThisWeek = DateTime.Today.AddDays(
-                DaysPerWeek - CalculateWeeklyDayOffset(DateTime.Today.DayOfWeek, firstDay));
-
-            DateTime prev = firstOccurrenceOfThisWeek;
+            DayOfWeek prev = firstDay;
 
             TimeSpan minGap = TimeSpan.FromDays(DaysPerWeek);
 
             foreach (DayOfWeek dayOfWeek in sortedDaysOfWeek.Skip(1))
             {
-                DateTime date = prev.AddDays(
-                        CalculateWeeklyDayOffset(dayOfWeek, prev.DayOfWeek));
-
-                TimeSpan gap = date - prev;
+                TimeSpan gap = TimeSpan.FromDays(CalculateWeeklyDayOffset(dayOfWeek, prev));
 
                 if (gap < minGap)
                 {
                     minGap = gap;
                 }
 
-                prev = date;
+                prev = dayOfWeek;
             }
 
             //
             // It may across weeks. Check the next week if the interval is one week.
             if (interval == 1)
             {
-                DateTime firstOccurrenceOfNextWeek = firstOccurrenceOfThisWeek.AddDays(DaysPerWeek);
-
-                TimeSpan gap = firstOccurrenceOfNextWeek - prev;
+                TimeSpan gap = TimeSpan.FromDays(CalculateWeeklyDayOffset(firstDay, prev));
 
                 if (gap < minGap)
                 {

--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
@@ -356,8 +356,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             TimeSpan minGap = TimeSpan.FromDays(DaysPerWeek);
 
-            foreach (DayOfWeek dayOfWeek in sortedDaysOfWeek.Skip(1))
+            for (int i = 1; i < sortedDaysOfWeek.Count(); i++) // start from the second day to calculate the gap
             {
+                DayOfWeek dayOfWeek = sortedDaysOfWeek[i];
+
                 TimeSpan gap = TimeSpan.FromDays(CalculateWeeklyDayOffset(dayOfWeek, prev));
 
                 if (gap < minGap)

--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
@@ -347,28 +347,27 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 return true;
             }
 
-            DateTime firstDayOfThisWeek = DateTime.Today.AddDays(
-                DaysPerWeek - CalculateWeeklyDayOffset(DateTime.Today.DayOfWeek, firstDayOfWeek));
-
             List<DayOfWeek> sortedDaysOfWeek = SortDaysOfWeek(daysOfWeek, firstDayOfWeek);
 
-            DateTime prev = DateTime.MinValue;
+            DayOfWeek firstDay = sortedDaysOfWeek.First(); // the closest occurrence day to the first day of week
+
+            DateTime firstOccurrenceOfThisWeek = DateTime.Today.AddDays(
+                DaysPerWeek - CalculateWeeklyDayOffset(DateTime.Today.DayOfWeek, firstDay));
+
+            DateTime prev = firstOccurrenceOfThisWeek;
 
             TimeSpan minGap = TimeSpan.FromDays(DaysPerWeek);
 
-            foreach (DayOfWeek dayOfWeek in sortedDaysOfWeek)
+            foreach (DayOfWeek dayOfWeek in sortedDaysOfWeek.Skip(1))
             {
-                DateTime date = firstDayOfThisWeek.AddDays(
-                        CalculateWeeklyDayOffset(dayOfWeek, firstDayOfWeek));
+                DateTime date = firstOccurrenceOfThisWeek.AddDays(
+                        CalculateWeeklyDayOffset(dayOfWeek, firstDay));
 
-                if (prev != DateTime.MinValue)
+                TimeSpan gap = date - prev;
+
+                if (gap < minGap)
                 {
-                    TimeSpan gap = date - prev;
-
-                    if (gap < minGap)
-                    {
-                        minGap = gap;
-                    }
+                    minGap = gap;
                 }
 
                 prev = date;
@@ -378,12 +377,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // It may across weeks. Check the next week if the interval is one week.
             if (interval == 1)
             {
-                DateTime firstDayOfNextWeek = firstDayOfThisWeek.AddDays(DaysPerWeek);
+                DateTime firstOccurrenceOfNextWeek = firstOccurrenceOfThisWeek.AddDays(DaysPerWeek);
 
-                DateTime firstOccurrenceInNextWeek = firstDayOfNextWeek.AddDays(
-                    CalculateWeeklyDayOffset(sortedDaysOfWeek.First(), firstDayOfWeek)); // firstDayOfWeek may not in the sortedDaysOfWeek
-
-                TimeSpan gap = firstOccurrenceInNextWeek - prev;
+                TimeSpan gap = firstOccurrenceOfNextWeek - prev;
 
                 if (gap < minGap)
                 {

--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
@@ -360,8 +360,8 @@ namespace Microsoft.FeatureManagement.FeatureFilters
 
             foreach (DayOfWeek dayOfWeek in sortedDaysOfWeek.Skip(1))
             {
-                DateTime date = firstOccurrenceOfThisWeek.AddDays(
-                        CalculateWeeklyDayOffset(dayOfWeek, firstDay));
+                DateTime date = prev.AddDays(
+                        CalculateWeeklyDayOffset(dayOfWeek, prev.DayOfWeek));
 
                 TimeSpan gap = date - prev;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/Recurrence/RecurrenceValidator.cs
@@ -402,7 +402,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         /// </summary>
         private static List<DayOfWeek> SortDaysOfWeek(IEnumerable<DayOfWeek> daysOfWeek, DayOfWeek firstDayOfWeek)
         {
-            List<DayOfWeek> result = daysOfWeek.ToList();
+            List<DayOfWeek> result = daysOfWeek.Distinct().ToList(); // dedup
 
             result.Sort((x, y) =>
                 CalculateWeeklyDayOffset(x, firstDayOfWeek)


### PR DESCRIPTION
## Why this PR?

The validation of recurrence configuration has been decoupled from recurrence evaluation. I forgot to update the related testcase. Also, update the implementation to make it more readable, not a bug fix.

related PR: #266 

## Visible Changes

-changes that are visible to developers using this library-
