### PR TITLE
Avoid using boolean.ToString and enum.ToString

### DIFF
--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsEventPublisher.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsEventPublisher.cs
@@ -51,7 +51,41 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
 
             foreach (var tag in activityEvent.Tags)
             {
-                properties[tag.Key] = tag.Value?.ToString();
+                // FeatureEvaluation event schema: https://github.com/microsoft/FeatureManagement/blob/main/Schema/FeatureEvaluationEvent/FeatureEvaluationEvent.v1.0.0.schema.json
+                if (tag.Key == "VariantAssignmentReason" && tag.Value is VariantAssignmentReason reason)
+                {
+                    switch (reason)
+                    {
+                        case VariantAssignmentReason.None:
+                            properties[tag.Key] = "None";
+                            break;
+                        case VariantAssignmentReason.DefaultWhenDisabled:
+                            properties[tag.Key] = "DefaultWhenDisabled";
+                            break;
+                        case VariantAssignmentReason.DefaultWhenEnabled:
+                            properties[tag.Key] = "DefaultWhenEnabled";
+                            break;
+                        case VariantAssignmentReason.User:
+                            properties[tag.Key] = "User";
+                            break;
+                        case VariantAssignmentReason.Group:
+                            properties[tag.Key] = "Group";
+                            break;
+                        case VariantAssignmentReason.Percentile:
+                            properties[tag.Key] = "Percentile";
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(activityEvent), "The variant assignment reason is unrecognizable.");
+                    }
+                }
+                else if (tag.Key == "Enabled" && tag.Value is bool enabled)
+                {
+                    properties[tag.Key] = enabled ? "True" : "False";
+                }
+                else
+                {
+                    properties[tag.Key] = tag.Value?.ToString();
+                }
             }
 
             _telemetryClient.TrackEvent("FeatureEvaluation", properties);

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsEventPublisher.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsEventPublisher.cs
@@ -52,7 +52,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
             foreach (var tag in activityEvent.Tags)
             {
                 // FeatureEvaluation event schema: https://github.com/microsoft/FeatureManagement/blob/main/Schema/FeatureEvaluationEvent/FeatureEvaluationEvent.v1.0.0.schema.json
-                if (tag.Key == "VariantAssignmentReason" && tag.Value is VariantAssignmentReason reason)
+                if (tag.Value is VariantAssignmentReason reason)
                 {
                     switch (reason)
                     {
@@ -78,9 +78,9 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
                             throw new ArgumentOutOfRangeException(nameof(activityEvent), "The variant assignment reason is unrecognizable.");
                     }
                 }
-                else if (tag.Key == "Enabled" && tag.Value is bool enabled)
+                else if (tag.Value is bool val)
                 {
-                    properties[tag.Key] = enabled ? "True" : "False";
+                    properties[tag.Key] = val ? "True" : "False";
                 }
                 else
                 {

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -380,6 +380,7 @@ namespace Microsoft.FeatureManagement
             Debug.Assert(evaluationEvent != null);
             Debug.Assert(evaluationEvent.FeatureDefinition != null);
 
+            // FeatureEvaluation event schema: https://github.com/microsoft/FeatureManagement/blob/main/Schema/FeatureEvaluationEvent/FeatureEvaluationEvent.v1.0.0.schema.json
             var tags = new ActivityTagsCollection()
             {
                 { "FeatureName", evaluationEvent.FeatureDefinition.Name },


### PR DESCRIPTION
## Why this PR?

Currently, we put `VariantAssignementReason` enum in the activity tags. [ref](https://github.com/microsoft/FeatureManagement-Dotnet/blob/main/src/Microsoft.FeatureManagement/FeatureManager.cs#L387)

When putting it into app insights telemetry, we call `ToString` on Enum type, this is not a good practice. Because, code refactoring may cause the value in telemetry changed.

We also call `ToString` on boolean, which will produce "True" instead of "true". Since all of our released packages have the same behavior, we should keep it. But it should be hard-coded. Like JS FM does [ref](https://github.com/microsoft/FeatureManagement-JavaScript/blob/main/src/feature-management/src/telemetry/featureEvaluationEvent.ts#L22) and [ref](https://github.com/microsoft/FeatureManagement-JavaScript/blob/main/src/feature-management/src/featureManager.ts#L222)
Related PR: https://github.com/microsoft/FeatureManagement/pull/26

## Visible Changes

No behavior change
