### PR TITLE
Adds cancellationtoken to the FeatureEvaluationContext- and respects …

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 //
 using Microsoft.Extensions.Configuration;
+using System.Threading;
 
 namespace Microsoft.FeatureManagement
 {
@@ -25,5 +26,10 @@ namespace Microsoft.FeatureManagement
         /// The settings are made available for <see cref="IFeatureFilter"/>s that implement <see cref="IFilterParametersBinder"/>.
         /// </summary>
         public object Settings { get; set; }
+
+        /// <summary>
+        /// A cancellation token that can be used to request cancellation of the feature evaluation operation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -30,6 +30,6 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// A cancellation token that can be used to request cancellation of the feature evaluation operation.
         /// </summary>
-        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
+        public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -472,6 +472,11 @@ namespace Microsoft.FeatureManagement
                 // For all enabling filters listed in the feature's state, evaluate them according to requirement type
                 foreach (FeatureFilterConfiguration featureFilterConfiguration in featureDefinition.EnabledFor)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     filterIndex++;
 
                     //
@@ -524,7 +529,8 @@ namespace Microsoft.FeatureManagement
                     var context = new FeatureFilterEvaluationContext()
                     {
                         FeatureName = featureDefinition.Name,
-                        Parameters = featureFilterConfiguration.Parameters
+                        Parameters = featureFilterConfiguration.Parameters,
+                        CancellationToken = cancellationToken
                     };
 
                     BindSettings(filter, context, filterIndex);
@@ -611,6 +617,11 @@ namespace Microsoft.FeatureManagement
             {
                 foreach (UserAllocation user in evaluationEvent.FeatureDefinition.Allocation.User)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     if (TargetingEvaluator.IsTargeted(targetingContext.UserId, user.Users, _assignerOptions.IgnoreCase))
                     {
                         if (string.IsNullOrEmpty(user.Variant))
@@ -637,6 +648,11 @@ namespace Microsoft.FeatureManagement
             {
                 foreach (GroupAllocation group in evaluationEvent.FeatureDefinition.Allocation.Group)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     if (TargetingEvaluator.IsTargeted(targetingContext.Groups, group.Groups, _assignerOptions.IgnoreCase))
                     {
                         if (string.IsNullOrEmpty(group.Variant))
@@ -663,6 +679,11 @@ namespace Microsoft.FeatureManagement
             {
                 foreach (PercentileAllocation percentile in evaluationEvent.FeatureDefinition.Allocation.Percentile)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     if (TargetingEvaluator.IsTargeted(
                         targetingContext,
                         percentile.From,
@@ -795,7 +816,7 @@ namespace Microsoft.FeatureManagement
             //
             // Feature filters can have namespaces in their alias
             // If a feature is configured to use a filter without a namespace such as 'MyFilter', then it can match 'MyOrg.MyProduct.MyFilter' or simply 'MyFilter'
-            // If a feature is configured to use a filter with a namespace such as 'MyOrg.MyProduct.MyFilter' then it can only match 'MyOrg.MyProduct.MyFilter' 
+            // If a feature is configured to use a filter with a namespace such as 'MyOrg.MyProduct.MyFilter' then it can only match 'MyOrg.MyProduct.MyFilter'
             if (filterName.Contains('.'))
             {
                 //

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -472,10 +472,7 @@ namespace Microsoft.FeatureManagement
                 // For all enabling filters listed in the feature's state, evaluate them according to requirement type
                 foreach (FeatureFilterConfiguration featureFilterConfiguration in featureDefinition.EnabledFor)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     filterIndex++;
 
@@ -617,10 +614,7 @@ namespace Microsoft.FeatureManagement
             {
                 foreach (UserAllocation user in evaluationEvent.FeatureDefinition.Allocation.User)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     if (TargetingEvaluator.IsTargeted(targetingContext.UserId, user.Users, _assignerOptions.IgnoreCase))
                     {
@@ -648,10 +642,7 @@ namespace Microsoft.FeatureManagement
             {
                 foreach (GroupAllocation group in evaluationEvent.FeatureDefinition.Allocation.Group)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     if (TargetingEvaluator.IsTargeted(targetingContext.Groups, group.Groups, _assignerOptions.IgnoreCase))
                     {
@@ -679,10 +670,7 @@ namespace Microsoft.FeatureManagement
             {
                 foreach (PercentileAllocation percentile in evaluationEvent.FeatureDefinition.Allocation.Percentile)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     if (TargetingEvaluator.IsTargeted(
                         targetingContext,


### PR DESCRIPTION
This pull request introduces a cancellation mechanism to the feature evaluation process in the `Microsoft.FeatureManagement` library. The changes ensure that long-running feature evaluations can be cancelled if needed, improving the responsiveness and control over feature management operations.

Key changes include:

### Cancellation Token Integration:

* [`src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs`](diffhunk://#diff-0bbd1d85437293673d4eea52a879c7a2f3ce212ff54a4db0eec1eeeb3a2918c1R29-R33): Added a `CancellationToken` property to the `FeatureFilterEvaluationContext` class to support cancellation of feature evaluation operations.

### Cancellation Checks:

* [`src/Microsoft.FeatureManagement/FeatureManager.cs`](diffhunk://#diff-7726d09bdcf1556c447fe12c6bd0f83385916697784034cec5d959edf8e7021aR475-R479): Added checks for `cancellationToken.IsCancellationRequested` in the `IsEnabledAsync` method to allow for early termination of the evaluation loop if cancellation is requested.
* [`src/Microsoft.FeatureManagement/FeatureManager.cs`](diffhunk://#diff-7726d09bdcf1556c447fe12c6bd0f83385916697784034cec5d959edf8e7021aL527-R533): Updated the `FeatureFilterEvaluationContext` instantiation to include the `CancellationToken` in the `IsEnabledAsync` method.
* [`src/Microsoft.FeatureManagement/FeatureManager.cs`](diffhunk://#diff-7726d09bdcf1556c447fe12c6bd0f83385916697784034cec5d959edf8e7021aR620-R624): Added checks for `cancellationToken.IsCancellationRequested` in the `AssignVariantAsync` method to handle cancellation during user, group, and percentile allocations. [[1]](diffhunk://#diff-7726d09bdcf1556c447fe12c6bd0f83385916697784034cec5d959edf8e7021aR620-R624) [[2]](diffhunk://#diff-7726d09bdcf1556c447fe12c6bd0f83385916697784034cec5d959edf8e7021aR651-R655) [[3]](diffhunk://#diff-7726d09bdcf1556c447fe12c6bd0f83385916697784034cec5d959edf8e7021aR682-R686)

These updates enhance the robustness of the feature management system by allowing operations to be cancelled gracefully, which can be particularly useful in scenarios where feature evaluations are time-sensitive or resource-intensive.

Addresses https://github.com/microsoft/FeatureManagement-Dotnet/issues/531 