### PR TITLE
Fixed broken link to JSON schema in MicrosoftFeatureManagementFields.cs

### DIFF
--- a/src/Microsoft.FeatureManagement/MicrosoftFeatureManagementFields.cs
+++ b/src/Microsoft.FeatureManagement/MicrosoftFeatureManagementFields.cs
@@ -4,14 +4,14 @@
 
 namespace Microsoft.FeatureManagement
 {
-    //
-    // Microsoft Feature Management schema: https://github.com/Azure/AppConfiguration/blob/main/docs/FeatureManagement/FeatureManagement.v1.0.0.schema.json
+    /// <summary>
+    /// See Microsoft Feature Management schema: https://github.com/microsoft/FeatureManagement/blob/main/Schema/FeatureManagement.v2.0.0.schema.json
+    /// </summary>
     internal static class MicrosoftFeatureManagementFields
     {
         public const string FeatureManagementSectionName = "feature_management";
         public const string FeatureFlagsSectionName = "feature_flags";
 
-        //
         // Microsoft feature flag keywords
         public const string Id = "id";
         public const string Enabled = "enabled";
@@ -19,7 +19,6 @@ namespace Microsoft.FeatureManagement
         public const string ClientFilters = "client_filters";
         public const string RequirementType = "requirement_type";
 
-        //
         // Allocation keywords
         public const string AllocationSectionName = "allocation";
         public const string AllocationDefaultWhenDisabled = "default_when_disabled";
@@ -34,7 +33,6 @@ namespace Microsoft.FeatureManagement
         public const string PercentileAllocationTo = "to";
         public const string AllocationSeed = "seed";
 
-        //
         // Client filter keywords
         public const string Name = "name";
         public const string Parameters = "parameters";


### PR DESCRIPTION
## Why this PR?

Broken link hurts readability and discoverability

## Visible Changes

- Replaced a broken link to JSON schema V1 with working link to JSON schema v2
- Used the XML doc format `/// <summary]`
- Removed empty like comments `//`