### PR TITLE
Dedupe when returning all feature names

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -196,11 +196,17 @@ namespace Microsoft.FeatureManagement
         /// <returns>An enumerator which provides asynchronous iteration over the feature names registered in the feature manager.</returns>
         public async IAsyncEnumerable<string> GetFeatureNamesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            var featureNamesReturned = new HashSet<string>();
             await foreach (FeatureDefinition featureDefinition in _featureDefinitionProvider.GetAllFeatureDefinitionsAsync().ConfigureAwait(false))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                yield return featureDefinition.Name;
+                if (!featureNamesReturned.Contains(featureDefinition.Name))
+                {
+                    yield return featureDefinition.Name;
+
+                    featureNamesReturned.Add(featureDefinition.Name);
+                }
             }
         }
 

--- a/tests/Tests.FeatureManagement/Tests.FeatureManagement.csproj
+++ b/tests/Tests.FeatureManagement/Tests.FeatureManagement.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
@@ -41,6 +41,9 @@
 
   <ItemGroup>
     <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.MultipleSchemas.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="DotnetFeatureManagementSchema.json">

--- a/tests/Tests.FeatureManagement/appsettings.MultipleSchemas.json
+++ b/tests/Tests.FeatureManagement/appsettings.MultipleSchemas.json
@@ -1,0 +1,22 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+
+  // MS schema will be prioritized, feature should be enabled
+  "feature_management": {
+    "feature_flags": [
+      {
+        "id": "DuplicateFlag",
+        "enabled": true
+      }
+    ]
+  },
+
+  "FeatureManagement": {
+    "DuplicateFlag": false
+  }
+} 


### PR DESCRIPTION
## Why this PR?

Closes #534

## Visible Changes

For developers using a `IFeatureDefinitionProvider` that can return multiple `FeatureDefinition` items with the same `Name`, as is the case with the built-in `Microsoft.FeatureManagement.ConfigurationFeatureDefinitionProvider` (which sources from the MS schema and the DotNet schema), `FeatureManagement::GetFeatureNamesAsync` will no longer return duplicates if a feature is configured multiple times (i.e. in each of those schema). 

This will help folks wanting to transition over gracefully, but _could_ be considered a breaking change to current behaviour.

Note: Duplicate feature names in the one schema is already de-duped, as a test I added proved.
