### PR TITLE
Rename TargetingId baggage

### DIFF
--- a/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/TargetingHttpContextMiddleware.cs
@@ -19,7 +19,7 @@ namespace Microsoft.FeatureManagement
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;
 
-        private const string TargetingIdKey = $"Microsoft.FeatureManagement.TargetingId";
+        private const string TargetingIdKey = "TargetingId";
 
         /// <summary>
         /// Creates an instance of the TargetingHttpContextMiddleware

--- a/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TargetingTelemetryInitializer.cs
+++ b/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/TargetingTelemetryInitializer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.FeatureManagement.Telemetry.ApplicationInsights
     /// </summary>
     public class TargetingTelemetryInitializer : ITelemetryInitializer
     {
-        private const string TargetingIdKey = $"Microsoft.FeatureManagement.TargetingId";
+        private const string TargetingIdKey = "TargetingId";
 
         /// <summary>
         /// When telemetry is initialized, adds targeting information to all relevant telemetry.


### PR DESCRIPTION
## Why this PR?

There are redundant `TargetingId` dimension in our telemetry.

![image](https://github.com/user-attachments/assets/19f3ad7c-6f8d-49a7-b0d6-9937c5de353b)

The `TargetingHttpContextMiddleware` adds `Microsoft.FeatureManagement.TargetingId` to http request activity baggage.

The baggage will be inherited by child activities and App Insights SDK will add it to the event's custom dimension.

[ref](https://learn.microsoft.com/en-us/azure/azure-monitor/app/custom-operations-tracking#applicationinsights-operations-vs-systemdiagnosticsactivity)