### PR TITLE
Merge Microsoft feature flags

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -400,6 +400,96 @@ namespace Microsoft.FeatureManagement
                     }
                 }
 
+                if (additionalDefinition.Allocation != null)
+                {
+                    if (mergedAllocation == null)
+                    {
+                        mergedAllocation = additionalDefinition.Allocation;
+                    }
+                    else
+                    {
+                        // Merge allocation properties, only override if not null
+                        if (!string.IsNullOrEmpty(additionalDefinition.Allocation.DefaultWhenEnabled))
+                        {
+                            mergedAllocation.DefaultWhenEnabled = additionalDefinition.Allocation.DefaultWhenEnabled;
+                        }
+
+                        if (!string.IsNullOrEmpty(additionalDefinition.Allocation.DefaultWhenDisabled))
+                        {
+                            mergedAllocation.DefaultWhenDisabled = additionalDefinition.Allocation.DefaultWhenDisabled;
+                        }
+
+                        if (!string.IsNullOrEmpty(additionalDefinition.Allocation.Seed))
+                        {
+                            mergedAllocation.Seed = additionalDefinition.Allocation.Seed;
+                        }
+
+                        if (additionalDefinition.Allocation.User != null)
+                        {
+                            var mergedUserAllocations = new List<UserAllocation>(mergedAllocation.User ?? Enumerable.Empty<UserAllocation>());
+
+                            foreach (UserAllocation userAllocation in additionalDefinition.Allocation.User)
+                            {
+                                int existingIndex = mergedUserAllocations.FindIndex(u => string.Equals(u.Variant, userAllocation.Variant, StringComparison.OrdinalIgnoreCase));
+
+                                if (existingIndex >= 0)
+                                {
+                                    mergedUserAllocations[existingIndex] = userAllocation;
+                                }
+                                else
+                                {
+                                    mergedUserAllocations.Add(userAllocation);
+                                }
+                            }
+
+                            mergedAllocation.User = mergedUserAllocations;
+                        }
+
+                        if (additionalDefinition.Allocation.Group != null)
+                        {
+                            var mergedGroupAllocations = new List<GroupAllocation>(mergedAllocation.Group ?? Enumerable.Empty<GroupAllocation>());
+
+                            foreach (GroupAllocation groupAllocation in additionalDefinition.Allocation.Group)
+                            {
+                                int existingIndex = mergedGroupAllocations.FindIndex(g => string.Equals(g.Variant, groupAllocation.Variant, StringComparison.OrdinalIgnoreCase));
+
+                                if (existingIndex >= 0)
+                                {
+                                    mergedGroupAllocations[existingIndex] = groupAllocation;
+                                }
+                                else
+                                {
+                                    mergedGroupAllocations.Add(groupAllocation);
+                                }
+                            }
+
+                            mergedAllocation.Group = mergedGroupAllocations;
+                        }
+
+                        // Merge Percentile allocations - replace existing allocations with same variant name
+                        if (additionalDefinition.Allocation.Percentile != null)
+                        {
+                            var mergedPercentileAllocations = new List<PercentileAllocation>(mergedAllocation.Percentile ?? Enumerable.Empty<PercentileAllocation>());
+
+                            foreach (PercentileAllocation percentileAllocation in additionalDefinition.Allocation.Percentile)
+                            {
+                                int existingIndex = mergedPercentileAllocations.FindIndex(p => string.Equals(p.Variant, percentileAllocation.Variant, StringComparison.OrdinalIgnoreCase));
+
+                                if (existingIndex >= 0)
+                                {
+                                    mergedPercentileAllocations[existingIndex] = percentileAllocation;
+                                }
+                                else
+                                {
+                                    mergedPercentileAllocations.Add(percentileAllocation);
+                                }
+                            }
+
+                            mergedAllocation.Percentile = mergedPercentileAllocations;
+                        }
+                    }
+                }
+
                 if (additionalDefinition.Telemetry?.Metadata != null)
                 {
                     foreach (KeyValuePair<string, string> kvp in additionalDefinition.Telemetry.Metadata)
@@ -410,11 +500,6 @@ namespace Microsoft.FeatureManagement
 
                 mergedRequirementType = additionalDefinition.RequirementType;
                 mergedStatus = additionalDefinition.Status;
-
-                if (additionalDefinition.Allocation != null)
-                {
-                    mergedAllocation = additionalDefinition.Allocation;
-                }
 
                 if (additionalDefinition.Telemetry != null)
                 {


### PR DESCRIPTION
## Why this PR?

#507 

There is a well-known [pitfall](https://rimdev.io/avoiding-aspnet-core-configuration-pitfalls-with-array-values) when merging array value in configuration system in .NET.

We presented a [solution](https://github.com/microsoft/FeatureManagement-Dotnet/pull/536) in v4.2.1: concatenate feature flag arrays and let the last feature definition win.

However, a [customer](https://github.com/microsoft/FeatureManagement-Dotnet/issues/507#issuecomment-3111322555) raised a concern that this behavior change will break their current usage. The customer’s team distributed  a base appsettings file in the docker image. Developers just want to toggle the feature flag and what they do is to use another configuration source and update the “enabled” field for certain feature flags.

Base appsettings.json:
```js
{
  "feature_management": {
    "feature_flags": [
      {
        "id": "FeatureA",
        "enabled": true,
        "conditions": {
          "client_filters": [ ... ]
        }
      },
      {
        "id": "FeatureB",
        "enabled": false,
        "variants": [ ... ],
        "allocation": { ... }
      }
    ]
  }
}
```

People may want to use the following appsetting.development.json file to toggle the “FeatureB” flag:
```js
{
  "feature_management": {
    "feature_flags": [
      {
        "id": "FeatureA",
        "enabled": true
      },
      {
        "id": "FeatureB",
        "enabled": true // toggle "FeatureB"
      }
    ]
  }
}
```

However, in 4.2.1, our concat ff arrays behavior will produce the following configuration:

```js
{
  "feature_management": {
    "feature_flags": [
      {
        "id": "FeatureA",
        "enabled": true,
        "conditions": {
          "client_filters": [ ... ]
        }
      },
      {
        "id": "FeatureB",
        "enabled": false,
        "variants": [ ... ],
        "allocation": { ... }
      },
      {
        "id": "FeatureA",
        "enabled": true
      },
      {
        "id": "FeatureB",
        "enabled": true
      }
    ]
  }
}
```

The merge result that customer wanted
```js
{
  "feature_management": {
    "feature_flags": [
      {
        "id": "FeatureA",
        "enabled": true,
        "conditions": {
          "client_filters": [ ... ]
        }
      },
      {
        "id": "FeatureB",
        "enabled": true, // toggled
        "variants": [ ... ],
        "allocation": { ... }
      }
    ]
  }
}
```

------------------------------------------------------------------------------

In addition, some customers may have the following usage:
appsettings.json
```js
{
    "feature_management": {
        "feature_flags": [
            {
                "id": "FeatureA",
                "enabled": true,
                "variants": [ ... ],
                "allocation": { ... }
            }
        ]
    }
}
```
appsettings.Production.json
```js
{
    "feature_management": {
        "feature_flags": [
            {
                "id": "FeatureA",
                 // enabled/variant/allocation field is not specified
                "conditions": {  // add condition for production
                    "client_filters": [
                        {
                            "name": "FeatureFilterA"
                        }
                    ]
                }
            }
        ]
    }
}
```
In short, what people is a layering-manner merge behavior. 

## Visible Changes

- This PR is built on #536 and #547. The `ConfigurationFeatureDefinitionProvider` will not only read `feature_flags` array from different `ConfigurationProvider`, but also it will maintain a dictionary where key is feature name and value is `List<IConfigurationSection>` that contains feature definition from different configuration source. In this case, `ConfigurationFeatureDefinitionProvider` can merge them in an intuitive manner:

- The later feature definition will override the previous feature defintion. The granularity of the override behavior is at the property level within the FeatureDefinition class. For example:
  ```js
  "feature_flags": [
      {
          "id": "FeatureA",
          "enabled": false，
          "variants": [
              {
                  "name": "Variant1",
                  "configuration_value": "Value1"
              },
              {
                  "name": "Variant2",
                  "configuration_value": "Value2"
              }
          ]
      },
      {
          "id": "FeatureA",
          "enabled": true，
          "variants": [
              {
                  "name": "Variant2",
                  "configuration_value": "Value2-updated"
              },
              {
                  "name": "Variant3",
                  "configuration_value": "Value3"
              },
          ],
          "conditions": {
              "client_filters": [...]
          }
      }
  ]
  ```
  The above configuration will produce such a feature definition after merging:

  ```js
  {
      "id": "FeatureA",
      "enabled": true，
      "variants": [
          {
              "name": "Variant1",
              "configuration_value": "Value1"
          },
          {
              "name": "Variant2",
              "configuration_value": "Value2-updated"
          },
          {
              "name": "Variant3",
              "configuration_value": "Value3"
          }
      ],
      "conditions": {
          "client_filters": [...]
      }
  }
  ```
  
  For more information, please go to testcases.


- A lock is used in the `EnsureInit` method.
