### PR TITLE
Make DefaultHttpTargetingContextAccessor public

### DIFF
--- a/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.FeatureManagement
     /// <summary>
     /// Provides a default implementation of <see cref="ITargetingContextAccessor"/> that creates <see cref="TargetingContext"/> using info from the current HTTP request.
     /// </summary>
-    internal sealed class DefaultHttpTargetingContextAccessor : ITargetingContextAccessor
+    public sealed class DefaultHttpTargetingContextAccessor : ITargetingContextAccessor
     {
         /// <summary>
         /// The key used to store and retrieve the <see cref="TargetingContext"/> from the <see cref="HttpContext"/> items.


### PR DESCRIPTION
## Why this PR?

#520

## Visible Changes

Now `DefaultHttpTargetingContextAccessor` is a public class.
