### PR TITLE
Expose time provider for TimeWindowFilter

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -37,9 +37,9 @@ namespace Microsoft.FeatureManagement.FeatureFilters
         public IMemoryCache Cache { get; set; }
 
         /// <summary>
-        /// This property allows the time window filter in our test suite to use simulated time.
+        /// This property allows the time window filter to use custom <see cref="TimeProvider"/>.
         /// </summary>
-        internal TimeProvider SystemClock { get; set; }
+        public TimeProvider SystemClock { get; set; }
 
         /// <summary>
         /// Binds configuration representing filter parameters to <see cref="TimeWindowFilterSettings"/>.

--- a/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.FeatureManagement/ServiceCollectionExtensions.cs
@@ -175,7 +175,8 @@ namespace Microsoft.FeatureManagement
             builder.AddFeatureFilter<TimeWindowFilter>(sp =>
                 new TimeWindowFilter()
                 {
-                    Cache = sp.GetRequiredService<IMemoryCache>()
+                    Cache = sp.GetRequiredService<IMemoryCache>(),
+                    SystemClock = sp.GetService<TimeProvider>() ?? TimeProvider.System,
                 });
 
             builder.AddFeatureFilter<ContextualTargetingFilter>();


### PR DESCRIPTION
## Why this PR?

#558

## Visible Changes

Now `TimeWindowFilter.SystemClock` is public.

DI usage:
```C#
builder.Services.AddSingleton<TimeProvider, CustomTimeProvider>();
builder.Services.AddFeatureManagement(); // feature manager builder will get TimeProvider service from DI container
```
If there is no registered `TimeProvider` service, `SystemTimeProvider` will be used.

Direct usage:
```C#
var mockedTimeWindowFilter = new TimeWindowFilter()
{
    SystemClock = mockedTimeProvider
};
```

