### PR TITLE
Fix binary incompatibility introduced by 4.4.0

### DIFF
--- a/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
+++ b/src/Microsoft.FeatureManagement/ConfigurationFeatureDefinitionProvider.cs
@@ -38,10 +38,18 @@ namespace Microsoft.FeatureManagement
         /// Creates a configuration feature definition provider.
         /// </summary>
         /// <param name="configuration">The configuration of feature definitions.</param>
+        public ConfigurationFeatureDefinitionProvider(IConfiguration configuration) : this(configuration, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a configuration feature definition provider.
+        /// </summary>
+        /// <param name="configuration">The configuration of feature definitions.</param>
         /// <param name="options">The options for the configuration feature definition provider.</param>
         public ConfigurationFeatureDefinitionProvider(
             IConfiguration configuration,
-            ConfigurationFeatureDefinitionProviderOptions options = null)
+            ConfigurationFeatureDefinitionProviderOptions options)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _options = options ?? new ConfigurationFeatureDefinitionProviderOptions();


### PR DESCRIPTION
## Why this PR?

4.4.0 [introduced](https://github.com/microsoft/FeatureManagement-Dotnet/commit/cb49942ef3fc17e839eda0aaefc79853b21cfa99) a change to `ConfigurationFeatureDefinitionProvider`, adding a nullable argument to the existing constructor. This was _source_ compatible, but not binary incompatible and so breaks (via `MissingMethodException`) any libraries that depend on it directly. 

## Visible Changes

The `ConfigurationFeatureDefinitionProviderOptions` constructor argument is separated into an overloaded constructor, restoring the < 4.4.0 constructor signature.