### PR TITLE
Refactor role claim retrieval to use identity-specific role claim type

### DIFF
--- a/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
@@ -53,8 +53,8 @@ namespace Microsoft.FeatureManagement
 
             //
             // Treat claims of type Role as groups
-            IEnumerable<string> groups = httpContext.User.Claims
-                .Where(c => c.Type == ClaimTypes.Role)
+            IEnumerable<string> groups = httpContext.User.Identities
+                .SelectMany(identity => identity.Claims.Where(c => c.Type == identity.RoleClaimType))
                 .Select(c => c.Value)
                 .ToList();
 

--- a/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
@@ -56,6 +56,7 @@ namespace Microsoft.FeatureManagement
             IEnumerable<string> groups = httpContext.User.Identities
                 .SelectMany(identity => identity.Claims.Where(c => c.Type == identity.RoleClaimType))
                 .Select(c => c.Value)
+                .Distinct()
                 .ToList();
 
             TargetingContext targetingContext = new TargetingContext

--- a/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
+++ b/src/Microsoft.FeatureManagement.AspNetCore/DefaultHttpTargetingContextAccessor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.FeatureManagement
             //
             // Treat claims of type Role as groups
             IEnumerable<string> groups = httpContext.User.Identities
-                .SelectMany(identity => identity.Claims.Where(c => c.Type == identity.RoleClaimType))
+                .SelectMany(identity => identity.Claims.Where(c => c.Type == identity.RoleClaimType || c.Type == ClaimTypes.Role))
                 .Select(c => c.Value)
                 .Distinct()
                 .ToList();


### PR DESCRIPTION
## Why this PR?
Currently RoleTypes are hardcoded to ClaimTypes.Role, which is not flexible if claims are mapped differently

