### PR TITLE
Update IFeatureDefinitionProviderCacheable interface to be public (#367)

### DIFF
--- a/src/Microsoft.FeatureManagement/IFeatureDefinitionProviderCacheable.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureDefinitionProviderCacheable.cs
@@ -7,7 +7,7 @@ namespace Microsoft.FeatureManagement
     /// <summary>
     /// An interface that marks this provider's parameters are cacheable. This was implemented to allow the provider in our test suite to be cacheable.
     /// </summary>
-    internal interface IFeatureDefinitionProviderCacheable
+    public interface IFeatureDefinitionProviderCacheable
     {
     }
 }


### PR DESCRIPTION
## Why this PR?
Allows extension of the existing IFeatureDefinitionProvider / ConfigurationFeatureDefinitionProvider without losing support for the parameter binding caching [as described in this issue comment](https://github.com/microsoft/FeatureManagement-Dotnet/issues/367#issuecomment-4112194604)

## Visible Changes
The `IFeatureDefinitionProviderCacheable` interface is update from `internal` to `public`
