### PR TITLE
Feature filter parameter object

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFilterConfiguration.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterConfiguration.cs
@@ -20,5 +20,13 @@ namespace Microsoft.FeatureManagement
         /// Configurable parameters that can change across instances of a feature filter.
         /// </summary>
         public IConfiguration Parameters { get; set; } = new ConfigurationRoot(new List<IConfigurationProvider>());
+
+        /// <summary>
+        /// A strongly-typed parameter object that can be used as an alternative to <see cref="Parameters"/>.
+        /// Custom <see cref="IFeatureDefinitionProvider"/> implementations can populate this property directly
+        /// instead of constructing an <see cref="IConfiguration"/> instance.
+        /// When set, feature filters should prefer this over <see cref="Parameters"/>.
+        /// </summary>
+        public object ParameterObject { get; set; }
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureFilterConfiguration.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.FeatureManagement
         public IConfiguration Parameters { get; set; } = new ConfigurationRoot(new List<IConfigurationProvider>());
 
         /// <summary>
-        /// A strongly-typed parameter object that can be used as an alternative to <see cref="Parameters"/>.
+        /// A parameter object that can be used as an alternative to <see cref="Parameters"/>.
         /// Custom <see cref="IFeatureDefinitionProvider"/> implementations can populate this property directly
         /// instead of constructing an <see cref="IConfiguration"/> instance.
         /// When set, feature filters should prefer this over <see cref="Parameters"/>.

--- a/src/Microsoft.FeatureManagement/FeatureFilterConfiguration.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterConfiguration.cs
@@ -27,6 +27,6 @@ namespace Microsoft.FeatureManagement
         /// instead of constructing an <see cref="IConfiguration"/> instance.
         /// When set, feature filters should prefer this over <see cref="Parameters"/>.
         /// </summary>
-        public object ParameterObject { get; set; }
+        public object ParametersObject { get; set; }
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -22,10 +22,9 @@ namespace Microsoft.FeatureManagement
         public IConfiguration Parameters { get; set; }
 
         /// <summary>
-        /// A strongly-typed parameter object, if any, provided by a custom <see cref="IFeatureDefinitionProvider"/>.
-        /// When set, feature filters should prefer this over <see cref="Parameters"/>.
+        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled. This property takes precedence over Parameters if both are provided.
         /// </summary>
-        public object ParameterObject { get; set; }
+        public object ParametersObject { get; set; }
 
         /// <summary>
         /// A settings object, if any, that has been pre-bound from <see cref="Parameters"/>.

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -22,6 +22,12 @@ namespace Microsoft.FeatureManagement
         public IConfiguration Parameters { get; set; }
 
         /// <summary>
+        /// A strongly-typed parameter object, if any, provided by a custom <see cref="IFeatureDefinitionProvider"/>.
+        /// When set, feature filters should prefer this over <see cref="Parameters"/>.
+        /// </summary>
+        public object ParameterObject { get; set; }
+
+        /// <summary>
         /// A settings object, if any, that has been pre-bound from <see cref="Parameters"/>.
         /// The settings are made available for <see cref="IFeatureFilter"/>s that implement <see cref="IFilterParametersBinder"/>.
         /// </summary>

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -22,7 +22,7 @@ namespace Microsoft.FeatureManagement
         public IConfiguration Parameters { get; set; }
 
         /// <summary>
-        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled. This property takes precedence over Parameters if both are provided.
+        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled. This property takes precedence over <see cref="Settings"/> if both are provided.
         /// </summary>
         public object ParametersObject { get; set; }
 

--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -22,7 +22,7 @@ namespace Microsoft.FeatureManagement
         public IConfiguration Parameters { get; set; }
 
         /// <summary>
-        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled. This property takes precedence over <see cref="Settings"/> if both are provided.
+        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled. This property takes precedence over <see cref="Settings"/> and <see cref="Parameters"/> if both are provided.
         /// </summary>
         public object ParametersObject { get; set; }
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -50,10 +50,24 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             }
 
             //
-            // Check if ParameterObject available (takes precedence), then prebound settings, otherwise bind from parameters.
-            PercentageFilterSettings settings = context.ParameterObject != null
-                ? (PercentageFilterSettings)context.ParameterObject
-                : (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
+            // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
+            PercentageFilterSettings settings;
+
+            if (context.ParametersObject != null)
+            {
+                if (!(context.ParametersObject is PercentageFilterSettings parametersObject))
+                {
+                    throw new FeatureManagementException(
+                        FeatureManagementError.InvalidParametersObject,
+                        $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(PercentageFilterSettings)}'.");
+                }
+
+                settings = parametersObject;
+            }
+            else
+            {
+                settings = (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
+            }
 
             bool result = true;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -50,8 +50,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             }
 
             //
-            // Check if prebound settings available, otherwise bind from parameters.
-            PercentageFilterSettings settings = (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
+            // Check if ParameterObject available (takes precedence), then prebound settings, otherwise bind from parameters.
+            PercentageFilterSettings settings = context.ParameterObject != null
+                ? (PercentageFilterSettings)context.ParameterObject
+                : (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
 
             bool result = true;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -53,21 +53,14 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
             PercentageFilterSettings settings;
 
-            if (context.ParametersObject != null)
+            if (context.ParametersObject != null && !(context.ParametersObject is PercentageFilterSettings parametersObject))
             {
-                if (!(context.ParametersObject is PercentageFilterSettings parametersObject))
-                {
-                    throw new FeatureManagementException(
-                        FeatureManagementError.InvalidParametersObject,
-                        $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(PercentageFilterSettings)}'.");
-                }
+                throw new ArgumentException(
+                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(PercentageFilterSettings)}'.",
+                    nameof(context.ParametersObject));
+            }
 
-                settings = parametersObject;
-            }
-            else
-            {
-                settings = (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
-            }
+            settings = (PercentageFilterSettings)context.ParametersObject ?? (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
 
             bool result = true;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
             PercentageFilterSettings settings;
 
-            if (context.ParametersObject != null && !(context.ParametersObject is PercentageFilterSettings parametersObject))
+            if (context.ParametersObject != null && !(context.ParametersObject is PercentageFilterSettings))
             {
                 throw new ArgumentException(
                     $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(PercentageFilterSettings)}'.",

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -74,21 +74,14 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
             TimeWindowFilterSettings settings;
 
-            if (context.ParametersObject != null)
+            if (context.ParametersObject != null && !(context.ParametersObject is TimeWindowFilterSettings parametersObject))
             {
-                if (!(context.ParametersObject is TimeWindowFilterSettings parametersObject))
-                {
-                    throw new FeatureManagementException(
-                        FeatureManagementError.InvalidParametersObject,
-                        $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TimeWindowFilterSettings)}'.");
-                }
+                throw new ArgumentException(
+                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TimeWindowFilterSettings)}'.",
+                    nameof(context.ParametersObject));
+            }
 
-                settings = parametersObject;
-            }
-            else
-            {
-                settings = (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
-            }
+            settings = (TimeWindowFilterSettings)context.ParametersObject ?? (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
 
             DateTimeOffset now = SystemClock?.GetUtcNow() ?? DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -71,10 +71,24 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             }
 
             //
-            // Check if ParameterObject available (takes precedence), then prebound settings, otherwise bind from parameters.
-            TimeWindowFilterSettings settings = context.ParameterObject != null
-                ? (TimeWindowFilterSettings)context.ParameterObject
-                : (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
+            // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
+            TimeWindowFilterSettings settings;
+
+            if (context.ParametersObject != null)
+            {
+                if (!(context.ParametersObject is TimeWindowFilterSettings parametersObject))
+                {
+                    throw new FeatureManagementException(
+                        FeatureManagementError.InvalidParametersObject,
+                        $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TimeWindowFilterSettings)}'.");
+                }
+
+                settings = parametersObject;
+            }
+            else
+            {
+                settings = (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
+            }
 
             DateTimeOffset now = SystemClock?.GetUtcNow() ?? DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -71,8 +71,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             }
 
             //
-            // Check if prebound settings available, otherwise bind from parameters.
-            TimeWindowFilterSettings settings = (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
+            // Check if ParameterObject available (takes precedence), then prebound settings, otherwise bind from parameters.
+            TimeWindowFilterSettings settings = context.ParameterObject != null
+                ? (TimeWindowFilterSettings)context.ParameterObject
+                : (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
 
             DateTimeOffset now = SystemClock?.GetUtcNow() ?? DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -74,7 +74,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
             TimeWindowFilterSettings settings;
 
-            if (context.ParametersObject != null && !(context.ParametersObject is TimeWindowFilterSettings parametersObject))
+            if (context.ParametersObject != null && !(context.ParametersObject is TimeWindowFilterSettings))
             {
                 throw new ArgumentException(
                     $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TimeWindowFilterSettings)}'.",

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -31,6 +31,11 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// The given configuration setting was invalid.
         /// </summary>
-        InvalidConfigurationSetting
+        InvalidConfigurationSetting,
+
+        /// <summary>
+        /// The <see cref="FeatureFilterConfiguration.ParametersObject"/> provided for a feature filter is not of the expected type.
+        /// </summary>
+        InvalidParametersObject
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManagementError.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementError.cs
@@ -31,11 +31,6 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// The given configuration setting was invalid.
         /// </summary>
-        InvalidConfigurationSetting,
-
-        /// <summary>
-        /// The <see cref="FeatureFilterConfiguration.ParametersObject"/> provided for a feature filter is not of the expected type.
-        /// </summary>
-        InvalidParametersObject
+        InvalidConfigurationSetting
     }
 }

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -498,6 +498,7 @@ namespace Microsoft.FeatureManagement
                     {
                         FeatureName = featureDefinition.Name,
                         Parameters = featureFilterConfiguration.Parameters,
+                        ParameterObject = featureFilterConfiguration.ParameterObject,
                         CancellationToken = cancellationToken
                     };
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -498,7 +498,7 @@ namespace Microsoft.FeatureManagement
                     {
                         FeatureName = featureDefinition.Name,
                         Parameters = featureFilterConfiguration.Parameters,
-                        ParameterObject = featureFilterConfiguration.ParameterObject,
+                        ParametersObject = featureFilterConfiguration.ParametersObject,
                         CancellationToken = cancellationToken
                     };
 

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
             TargetingFilterSettings settings;
 
-            if (context.ParametersObject != null && !(context.ParametersObject is TargetingFilterSettings parametersObject))
+            if (context.ParametersObject != null && !(context.ParametersObject is TargetingFilterSettings))
             {
                 throw new ArgumentException(
                     $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TargetingFilterSettings)}'.",

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -68,8 +68,10 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             }
 
             //
-            // Check if prebound settings available, otherwise bind from parameters.
-            TargetingFilterSettings settings = (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
+            // Check if ParameterObject available (takes precedence), then prebound settings, otherwise bind from parameters.
+            TargetingFilterSettings settings = context.ParameterObject != null
+                ? (TargetingFilterSettings)context.ParameterObject
+                : (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
 
             return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, settings, _options.IgnoreCase, context.FeatureName));
         }

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -71,21 +71,14 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
             TargetingFilterSettings settings;
 
-            if (context.ParametersObject != null)
+            if (context.ParametersObject != null && !(context.ParametersObject is TargetingFilterSettings parametersObject))
             {
-                if (!(context.ParametersObject is TargetingFilterSettings parametersObject))
-                {
-                    throw new FeatureManagementException(
-                        FeatureManagementError.InvalidParametersObject,
-                        $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TargetingFilterSettings)}'.");
-                }
+                throw new ArgumentException(
+                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TargetingFilterSettings)}'.",
+                    nameof(context.ParametersObject));
+            }
 
-                settings = parametersObject;
-            }
-            else
-            {
-                settings = (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
-            }
+            settings = (TargetingFilterSettings)context.ParametersObject ?? (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
 
             return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, settings, _options.IgnoreCase, context.FeatureName));
         }

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -68,10 +68,24 @@ namespace Microsoft.FeatureManagement.FeatureFilters
             }
 
             //
-            // Check if ParameterObject available (takes precedence), then prebound settings, otherwise bind from parameters.
-            TargetingFilterSettings settings = context.ParameterObject != null
-                ? (TargetingFilterSettings)context.ParameterObject
-                : (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
+            // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
+            TargetingFilterSettings settings;
+
+            if (context.ParametersObject != null)
+            {
+                if (!(context.ParametersObject is TargetingFilterSettings parametersObject))
+                {
+                    throw new FeatureManagementException(
+                        FeatureManagementError.InvalidParametersObject,
+                        $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TargetingFilterSettings)}'.");
+                }
+
+                settings = parametersObject;
+            }
+            else
+            {
+                settings = (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
+            }
 
             return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, settings, _options.IgnoreCase, context.FeatureName));
         }

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1890,9 +1890,7 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(() => featureManager.IsEnabledAsync("BadFeature"));
-
-            Assert.Equal(FeatureManagementError.InvalidParametersObject, e.Error);
+            await Assert.ThrowsAsync<ArgumentException>(() => featureManager.IsEnabledAsync("BadFeature"));
         }
 
         [Fact]
@@ -1925,9 +1923,7 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(() => featureManager.IsEnabledAsync("BadFeature"));
-
-            Assert.Equal(FeatureManagementError.InvalidParametersObject, e.Error);
+            await Assert.ThrowsAsync<ArgumentException>(() => featureManager.IsEnabledAsync("BadFeature"));
         }
     }
 

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1051,6 +1051,124 @@ namespace Tests.FeatureManagement
 
             Assert.True(called);
         }
+
+        [Fact]
+        public async Task UsesParameterObject()
+        {
+            var parameterObject = new object();
+
+            FeatureFilterConfiguration testFilterConfiguration = new FeatureFilterConfiguration
+            {
+                Name = "Test",
+                ParameterObject = parameterObject
+            };
+
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = Features.ConditionalFeature,
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            testFilterConfiguration
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<TestFilter>();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            IEnumerable<IFeatureFilterMetadata> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
+
+            TestFilter testFeatureFilter = (TestFilter)featureFilters.First(f => f is TestFilter);
+
+            testFeatureFilter.Callback = (evaluationContext) =>
+            {
+                //
+                // When ParameterObject is set, it should be available on the context
+                // so custom filters can use it with their own precedence logic.
+                Assert.Same(parameterObject, evaluationContext.ParameterObject);
+
+                return Task.FromResult(true);
+            };
+
+            bool result = await featureManager.IsEnabledAsync(Features.ConditionalFeature);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task ParameterObjectFallsBackToParametersWhenNull()
+        {
+            FeatureFilterConfiguration testFilterConfiguration = new FeatureFilterConfiguration
+            {
+                Name = "Test",
+                ParameterObject = null
+            };
+
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = Features.ConditionalFeature,
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            testFilterConfiguration
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<TestFilter>();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            IEnumerable<IFeatureFilterMetadata> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
+
+            TestFilter testFeatureFilter = (TestFilter)featureFilters.First(f => f is TestFilter);
+
+            bool binderCalled = false;
+
+            testFeatureFilter.ParametersBinderCallback = (parameters) =>
+            {
+                binderCalled = true;
+
+                return parameters;
+            };
+
+            testFeatureFilter.Callback = (evaluationContext) =>
+            {
+                //
+                // When ParameterObject is null, Settings should be populated
+                // by IFilterParametersBinder as usual.
+                Assert.Null(evaluationContext.ParameterObject);
+                Assert.NotNull(evaluationContext.Settings);
+
+                return Task.FromResult(true);
+            };
+
+            bool result = await featureManager.IsEnabledAsync(Features.ConditionalFeature);
+
+            Assert.True(result);
+
+            Assert.True(binderCalled);
+        }
     }
 
     public class FeatureManagementBuiltInFeatureFilterTest
@@ -1670,6 +1788,142 @@ namespace Tests.FeatureManagement
             IFeatureManager featureManager = provider.GetRequiredService<IFeatureManager>();
 
             Assert.True(await featureManager.IsEnabledAsync("CustomFilterFeature"));
+        }
+
+        [Fact]
+        public async Task PercentageFilterUsesParameterObject()
+        {
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = "PercentageFeature",
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            new FeatureFilterConfiguration
+                            {
+                                Name = "Microsoft.Percentage",
+                                ParameterObject = new PercentageFilterSettings { Value = 100 }
+                            }
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync("PercentageFeature"));
+        }
+
+        [Fact]
+        public async Task TimeWindowFilterUsesParameterObject()
+        {
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = "TimeWindowFeature",
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            new FeatureFilterConfiguration
+                            {
+                                Name = "Microsoft.TimeWindow",
+                                ParameterObject = new TimeWindowFilterSettings
+                                {
+                                    Start = DateTimeOffset.UtcNow.AddDays(-1),
+                                    End = DateTimeOffset.UtcNow.AddDays(1)
+                                }
+                            }
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            Assert.True(await featureManager.IsEnabledAsync("TimeWindowFeature"));
+        }
+
+        [Fact]
+        public async Task PercentageFilterThrowsOnInvalidParameterObjectType()
+        {
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = "BadFeature",
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            new FeatureFilterConfiguration
+                            {
+                                Name = "Microsoft.Percentage",
+                                ParameterObject = "wrong type"
+                            }
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            await Assert.ThrowsAsync<InvalidCastException>(() => featureManager.IsEnabledAsync("BadFeature"));
+        }
+
+        [Fact]
+        public async Task TimeWindowFilterThrowsOnInvalidParameterObjectType()
+        {
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = "BadFeature",
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            new FeatureFilterConfiguration
+                            {
+                                Name = "Microsoft.TimeWindow",
+                                ParameterObject = 42
+                            }
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            await Assert.ThrowsAsync<InvalidCastException>(() => featureManager.IsEnabledAsync("BadFeature"));
         }
     }
 

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1053,14 +1053,14 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task UsesParameterObject()
+        public async Task UsesParametersObject()
         {
             var parameterObject = new object();
 
             FeatureFilterConfiguration testFilterConfiguration = new FeatureFilterConfiguration
             {
                 Name = "Test",
-                ParameterObject = parameterObject
+                ParametersObject = parameterObject
             };
 
             var services = new ServiceCollection();
@@ -1094,9 +1094,9 @@ namespace Tests.FeatureManagement
             testFeatureFilter.Callback = (evaluationContext) =>
             {
                 //
-                // When ParameterObject is set, it should be available on the context
+                // When ParametersObject is set, it should be available on the context
                 // so custom filters can use it with their own precedence logic.
-                Assert.Same(parameterObject, evaluationContext.ParameterObject);
+                Assert.Same(parameterObject, evaluationContext.ParametersObject);
 
                 return Task.FromResult(true);
             };
@@ -1107,12 +1107,12 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task ParameterObjectFallsBackToParametersWhenNull()
+        public async Task ParametersObjectFallsBackToParametersWhenNull()
         {
             FeatureFilterConfiguration testFilterConfiguration = new FeatureFilterConfiguration
             {
                 Name = "Test",
-                ParameterObject = null
+                ParametersObject = null
             };
 
             var services = new ServiceCollection();
@@ -1155,9 +1155,9 @@ namespace Tests.FeatureManagement
             testFeatureFilter.Callback = (evaluationContext) =>
             {
                 //
-                // When ParameterObject is null, Settings should be populated
+                // When ParametersObject is null, Settings should be populated
                 // by IFilterParametersBinder as usual.
-                Assert.Null(evaluationContext.ParameterObject);
+                Assert.Null(evaluationContext.ParametersObject);
                 Assert.NotNull(evaluationContext.Settings);
 
                 return Task.FromResult(true);
@@ -1791,7 +1791,7 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task PercentageFilterUsesParameterObject()
+        public async Task PercentageFilterUsesParametersObject()
         {
             var services = new ServiceCollection();
 
@@ -1806,7 +1806,7 @@ namespace Tests.FeatureManagement
                             new FeatureFilterConfiguration
                             {
                                 Name = "Microsoft.Percentage",
-                                ParameterObject = new PercentageFilterSettings { Value = 100 }
+                                ParametersObject = new PercentageFilterSettings { Value = 100 }
                             }
                         }
                     }
@@ -1824,7 +1824,7 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task TimeWindowFilterUsesParameterObject()
+        public async Task TimeWindowFilterUsesParametersObject()
         {
             var services = new ServiceCollection();
 
@@ -1839,7 +1839,7 @@ namespace Tests.FeatureManagement
                             new FeatureFilterConfiguration
                             {
                                 Name = "Microsoft.TimeWindow",
-                                ParameterObject = new TimeWindowFilterSettings
+                                ParametersObject = new TimeWindowFilterSettings
                                 {
                                     Start = DateTimeOffset.UtcNow.AddDays(-1),
                                     End = DateTimeOffset.UtcNow.AddDays(1)
@@ -1861,7 +1861,7 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
-        public async Task PercentageFilterThrowsOnInvalidParameterObjectType()
+        public async Task PercentageFilterThrowsOnInvalidParametersObjectType()
         {
             var services = new ServiceCollection();
 
@@ -1876,7 +1876,7 @@ namespace Tests.FeatureManagement
                             new FeatureFilterConfiguration
                             {
                                 Name = "Microsoft.Percentage",
-                                ParameterObject = "wrong type"
+                                ParametersObject = "wrong type"
                             }
                         }
                     }
@@ -1890,11 +1890,13 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            await Assert.ThrowsAsync<InvalidCastException>(() => featureManager.IsEnabledAsync("BadFeature"));
+            FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(() => featureManager.IsEnabledAsync("BadFeature"));
+
+            Assert.Equal(FeatureManagementError.InvalidParametersObject, e.Error);
         }
 
         [Fact]
-        public async Task TimeWindowFilterThrowsOnInvalidParameterObjectType()
+        public async Task TimeWindowFilterThrowsOnInvalidParametersObjectType()
         {
             var services = new ServiceCollection();
 
@@ -1909,7 +1911,7 @@ namespace Tests.FeatureManagement
                             new FeatureFilterConfiguration
                             {
                                 Name = "Microsoft.TimeWindow",
-                                ParameterObject = 42
+                                ParametersObject = 42
                             }
                         }
                     }
@@ -1923,7 +1925,9 @@ namespace Tests.FeatureManagement
 
             IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
 
-            await Assert.ThrowsAsync<InvalidCastException>(() => featureManager.IsEnabledAsync("BadFeature"));
+            FeatureManagementException e = await Assert.ThrowsAsync<FeatureManagementException>(() => featureManager.IsEnabledAsync("BadFeature"));
+
+            Assert.Equal(FeatureManagementError.InvalidParametersObject, e.Error);
         }
     }
 


### PR DESCRIPTION
## Overview

This PR introduces a new `ParameterObject` property to `FeatureFilterEvaluationContext`, enabling custom `IFeatureDefinitionProvider` implementations to supply feature filter settings directly without requiring `IConfiguration`.

## Motivation

Currently, feature filters receive their configuration through `IConfiguration`, which works well for JSON/config file-based feature definitions. However, custom `IFeatureDefinitionProvider` implementations that source feature definitions from alternative backends (e.g., databases, REST APIs, gRPC services) are forced to:

1. Construct an `IConfiguration` object from their native data format
2. Have filters bind that configuration back to strongly-typed settings objects

This round-trip is unnecessary overhead when the provider already has the ability to create strongly-typed settings objects like `TargetingFilterSettings` or `TimeWindowFilterSettings` directly.

## Code Examples - Before & After

### Before: Using `IConfiguration` with `InMemoryCollection`

When implementing a custom `IFeatureDefinitionProvider` that fetches feature definitions from a database, you previously had to construct an `IConfiguration` object to pass filter parameters:

```csharp
// Fetch from database
var dbFeature = await _database.GetFeatureAsync(featureName);

// Must convert to IConfiguration even though we already have the data
var configData = new Dictionary<string, string>
{
    ["Audience:Users:0"] = dbFeature.TargetedUsers[0],
    ["Audience:Users:1"] = dbFeature.TargetedUsers[1],
    ["Audience:Groups:0:Name"] = dbFeature.TargetedGroups[0].Name,
    ["Audience:Groups:0:RolloutPercentage"] = dbFeature.TargetedGroups[0].RolloutPercentage.ToString(),
    ["Audience:DefaultRolloutPercentage"] = dbFeature.DefaultRolloutPercentage.ToString()
};

return new FeatureDefinition
{
    Name = featureName,
    EnabledFor = new[]
    {
        new FeatureFilterConfiguration
        {
            Name = "Targeting",
            Parameters = new ConfigurationBuilder()
                .AddInMemoryCollection(configData)
                .Build()
        }
    }
};
```

This approach has several drawbacks:
- Verbose dictionary key construction with magic strings
- Error-prone index management for arrays
- Unnecessary serialization to key-value pairs just to deserialize back to objects

### After: Using `ParameterObject` Directly

With the new `ParameterObject` property, custom providers can supply strongly-typed settings directly:

```csharp
// Fetch from database
var dbFeature = await _database.GetFeatureAsync(featureName);

// Directly create strongly-typed settings
var targetingSettings = new TargetingFilterSettings
{
    Audience = new TargetingFilterAudience
    {
        Users = dbFeature.TargetedUsers,
        Groups = dbFeature.TargetedGroups.Select(g => new GroupRollout
        {
            Name = g.Name,
            RolloutPercentage = g.RolloutPercentage
        }).ToList(),
        DefaultRolloutPercentage = dbFeature.DefaultRolloutPercentage
    }
};

return new FeatureDefinition
{
    Name = featureName,
    EnabledFor = new[]
    {
        new FeatureFilterConfiguration
        {
            Name = "Targeting",
            ParameterObject = targetingSettings  // Direct assignment!
        }
    }
};
```

## Changes

- **`FeatureFilterEvaluationContext`**: Added `ParameterObject` property to hold strongly-typed settings provided by custom providers
- **Built-in filters updated** (`PercentageFilter`, `TimeWindowFilter`, `ContextualTargetingFilter`): Now check `ParameterObject` first before falling back to `Settings` or binding from `Parameters`

## Precedence Order

When evaluating filter settings:

1. `ParameterObject` (if set) — Direct strongly-typed object from provider
2. `Settings` — Pre-bound settings via `IFilterParametersBinder`
3. `Parameters` — Bind from `IConfiguration`

The expectation is that systems using `ParameterObject` will not set `Parameters`/`IConfiguration`.
