### PR TITLE
Skip parameter binding if ParamemtersObject provided

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -684,6 +684,7 @@ namespace Microsoft.FeatureManagement
             // Skip parameter binding if the provider has already supplied a parameters object.
             if (context.ParametersObject != null)
             {
+                context.Settings = context.ParametersObject;
                 return;
             }
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -681,6 +681,12 @@ namespace Microsoft.FeatureManagement
                 return;
             }
 
+            // Skip parameter binding if the provider has already supplied a parameters object.
+            if (context.ParametersObject != null)
+            {
+                return;
+            }
+
             if (!(context.Parameters is ConfigurationWrapper) || Cache == null)
             {
                 context.Settings = binder.BindParameters(context.Parameters);

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -685,9 +685,8 @@ namespace Microsoft.FeatureManagement
             }
 
             // Skip parameter binding if the provider has already supplied a parameters object.
-            if (context.ParametersObject != null)
+            if (context.Settings != null)
             {
-                context.Settings = context.ParametersObject;
                 return;
             }
 

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1925,6 +1925,121 @@ namespace Tests.FeatureManagement
 
             await Assert.ThrowsAsync<ArgumentException>(() => featureManager.IsEnabledAsync("BadFeature"));
         }
+
+        [Fact]
+        public async Task TargetingFilterUsesParametersObject()
+        {
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = "TargetingFeature",
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            new FeatureFilterConfiguration
+                            {
+                                Name = "Microsoft.Targeting",
+                                ParametersObject = new TargetingFilterSettings
+                                {
+                                    Audience = new Audience
+                                    {
+                                        Users = new List<string> { "Jeff" },
+                                        Groups = new List<GroupRollout>
+                                        {
+                                            new GroupRollout
+                                            {
+                                                Name = "Ring1",
+                                                RolloutPercentage = 100
+                                            }
+                                        },
+                                        DefaultRolloutPercentage = 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IVariantFeatureManager featureManager = serviceProvider.GetRequiredService<IVariantFeatureManager>();
+
+            //
+            // Targeted user should be enabled
+            var targetingContext = new TargetingContext
+            {
+                UserId = "Jeff",
+                Groups = new List<string> { "Ring0" }
+            };
+
+            Assert.True(await featureManager.IsEnabledAsync("TargetingFeature", targetingContext));
+
+            //
+            // User in targeted group should be enabled
+            targetingContext = new TargetingContext
+            {
+                UserId = "NotTargeted",
+                Groups = new List<string> { "Ring1" }
+            };
+
+            Assert.True(await featureManager.IsEnabledAsync("TargetingFeature", targetingContext));
+
+            //
+            // Non-targeted user should be disabled (0% default rollout)
+            targetingContext = new TargetingContext
+            {
+                UserId = "NotTargeted",
+                Groups = new List<string> { "Ring0" }
+            };
+
+            Assert.False(await featureManager.IsEnabledAsync("TargetingFeature", targetingContext));
+        }
+
+        [Fact]
+        public async Task TargetingFilterThrowsOnInvalidParametersObjectType()
+        {
+            var services = new ServiceCollection();
+
+            var definitionProvider = new InMemoryFeatureDefinitionProvider(
+                new FeatureDefinition[]
+                {
+                    new FeatureDefinition
+                    {
+                        Name = "BadFeature",
+                        EnabledFor = new List<FeatureFilterConfiguration>()
+                        {
+                            new FeatureFilterConfiguration
+                            {
+                                Name = "Microsoft.Targeting",
+                                ParametersObject = "wrong type"
+                            }
+                        }
+                    }
+                });
+
+            services.AddSingleton<IFeatureDefinitionProvider>(definitionProvider)
+                    .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+                    .AddFeatureManagement();
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IVariantFeatureManager featureManager = serviceProvider.GetRequiredService<IVariantFeatureManager>();
+
+            var targetingContext = new TargetingContext
+            {
+                UserId = "Jeff",
+                Groups = new List<string>()
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => featureManager.IsEnabledAsync("BadFeature", targetingContext).AsTask());
+        }
     }
 
     public class FeatureManagementVariantTest


### PR DESCRIPTION
## Why this PR?

The `BindSettings` method wasn't updated to skip when `ParametersObject` is set — it still calls `BindParameters`, which fails on empty config.

## Visible Changes

Skip bind settings when `ParametersObject` is set.
