### PR TITLE
Consolidate ParametersObject into Settings on FeatureFilterEvaluationContext

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilterEvaluationContext.cs
@@ -22,13 +22,12 @@ namespace Microsoft.FeatureManagement
         public IConfiguration Parameters { get; set; }
 
         /// <summary>
-        /// The settings provided for the feature filter to use when evaluating whether the feature should be enabled. This property takes precedence over <see cref="Settings"/> and <see cref="Parameters"/> if both are provided.
-        /// </summary>
-        public object ParametersObject { get; set; }
-
-        /// <summary>
-        /// A settings object, if any, that has been pre-bound from <see cref="Parameters"/>.
-        /// The settings are made available for <see cref="IFeatureFilter"/>s that implement <see cref="IFilterParametersBinder"/>.
+        /// A settings object, if any, provided for the feature filter to use when evaluating whether the feature should be enabled.
+        /// This property is populated in two cases:
+        /// <list type="bullet">
+        /// <item>For features that provide parameters as an object, via <see cref="FeatureFilterConfiguration.ParametersObject"/>.</item>
+        /// <item>For <see cref="IFeatureFilter"/>s that implement <see cref="IFilterParametersBinder"/>.</item>
+        /// </list>
         /// </summary>
         public object Settings { get; set; }
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/PercentageFilter.cs
@@ -49,18 +49,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            //
-            // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
-            PercentageFilterSettings settings;
-
-            if (context.ParametersObject != null && !(context.ParametersObject is PercentageFilterSettings))
+            if (context.Settings != null && !(context.Settings is PercentageFilterSettings))
             {
                 throw new ArgumentException(
-                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(PercentageFilterSettings)}'.",
-                    nameof(context.ParametersObject));
+                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.Settings)} value of type '{context.Settings.GetType()}', but expected '{typeof(PercentageFilterSettings)}'.",
+                    nameof(context.Settings));
             }
 
-            settings = (PercentageFilterSettings)context.ParametersObject ?? (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
+            //
+            // Check if prebound settings available, otherwise bind from parameters.
+            PercentageFilterSettings settings = (PercentageFilterSettings)context.Settings ?? (PercentageFilterSettings)BindParameters(context.Parameters);
 
             bool result = true;
 

--- a/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
+++ b/src/Microsoft.FeatureManagement/FeatureFilters/TimeWindowFilter.cs
@@ -70,18 +70,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            //
-            // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
-            TimeWindowFilterSettings settings;
-
-            if (context.ParametersObject != null && !(context.ParametersObject is TimeWindowFilterSettings))
+            if (context.Settings != null && !(context.Settings is TimeWindowFilterSettings))
             {
                 throw new ArgumentException(
-                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TimeWindowFilterSettings)}'.",
-                    nameof(context.ParametersObject));
+                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.Settings)} value of type '{context.Settings.GetType()}', but expected '{typeof(TimeWindowFilterSettings)}'.",
+                    nameof(context.Settings));
             }
 
-            settings = (TimeWindowFilterSettings)context.ParametersObject ?? (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
+            //
+            // Check if prebound settings available, otherwise bind from parameters.
+            TimeWindowFilterSettings settings = (TimeWindowFilterSettings)context.Settings ?? (TimeWindowFilterSettings)BindParameters(context.Parameters);
 
             DateTimeOffset now = SystemClock?.GetUtcNow() ?? DateTimeOffset.UtcNow;
 

--- a/src/Microsoft.FeatureManagement/FeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManager.cs
@@ -498,11 +498,14 @@ namespace Microsoft.FeatureManagement
                     {
                         FeatureName = featureDefinition.Name,
                         Parameters = featureFilterConfiguration.Parameters,
-                        ParametersObject = featureFilterConfiguration.ParametersObject,
+                        Settings = featureFilterConfiguration.ParametersObject,
                         CancellationToken = cancellationToken
                     };
 
-                    BindSettings(filter, context, filterIndex);
+                    if (context.Settings == null)
+                    {
+                        BindSettings(filter, context, filterIndex);
+                    }
 
                     //
                     // IContextualFeatureFilter

--- a/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
+++ b/src/Microsoft.FeatureManagement/Targeting/ContextualTargetingFilter.cs
@@ -67,18 +67,16 @@ namespace Microsoft.FeatureManagement.FeatureFilters
                 throw new ArgumentNullException(nameof(targetingContext));
             }
 
-            //
-            // Check if ParametersObject available (takes precedence), then prebound settings, otherwise bind from parameters.
-            TargetingFilterSettings settings;
-
-            if (context.ParametersObject != null && !(context.ParametersObject is TargetingFilterSettings))
+            if (context.Settings != null && !(context.Settings is TargetingFilterSettings))
             {
                 throw new ArgumentException(
-                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.ParametersObject)} of type '{context.ParametersObject.GetType()}', but expected '{typeof(TargetingFilterSettings)}'.",
-                    nameof(context.ParametersObject));
+                    $"The '{Alias}' feature filter for feature '{context.FeatureName}' has a {nameof(context.Settings)} value of type '{context.Settings.GetType()}', but expected '{typeof(TargetingFilterSettings)}'.",
+                    nameof(context.Settings));
             }
 
-            settings = (TargetingFilterSettings)context.ParametersObject ?? (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
+            //
+            // Check if prebound settings available, otherwise bind from parameters.
+            TargetingFilterSettings settings = (TargetingFilterSettings)context.Settings ?? (TargetingFilterSettings)BindParameters(context.Parameters);
 
             return Task.FromResult(TargetingEvaluator.IsTargeted(targetingContext, settings, _options.IgnoreCase, context.FeatureName));
         }

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -1094,9 +1094,9 @@ namespace Tests.FeatureManagement
             testFeatureFilter.Callback = (evaluationContext) =>
             {
                 //
-                // When ParametersObject is set, it should be available on the context
-                // so custom filters can use it with their own precedence logic.
-                Assert.Same(parameterObject, evaluationContext.ParametersObject);
+                // When ParametersObject is set, it should be available on the context via settings
+                // so custom filters can use it.
+                Assert.Same(parameterObject, evaluationContext.Settings);
 
                 return Task.FromResult(true);
             };
@@ -1157,7 +1157,6 @@ namespace Tests.FeatureManagement
                 //
                 // When ParametersObject is null, Settings should be populated
                 // by IFilterParametersBinder as usual.
-                Assert.Null(evaluationContext.ParametersObject);
                 Assert.NotNull(evaluationContext.Settings);
 
                 return Task.FromResult(true);


### PR DESCRIPTION
Removes the ParametersObject property from FeatureFilterEvaluationContext and unifies its functionality into the existing Settings property.

## Motivation
ParametersObject and Settings served overlapping roles on the evaluation context — both carried a pre-resolved settings object for filters. Consolidating them into a single property simplifies the API surface and the fallback logic in

## Changes: 
* `FeatureFilterEvaluationContext`: Removed ParametersObject. The Settings property now serves both purposes — receiving pre-provided parameter objects (via FeatureFilterConfiguration.ParametersObject) and pre-bound settings from IFilterParametersBinder.
* `FeatureManager`: Assigns FeatureFilterConfiguration.ParametersObject directly to Settings on the evaluation context. Skips BindSettings when Settings is already populated.
* Built-in filters (PercentageFilter, TimeWindowFilter, ContextualTargetingFilter): Simplified from a three-way fallback (ParametersObject ?? Settings ?? BindParameters) to a two-way fallback (Settings ?? BindParameters).
* Tests: Updated assertions and removed references to the deleted property.
