### PR TITLE
support variant service match mode

### DIFF
--- a/src/Microsoft.FeatureManagement/FeatureManagementBuilderExtensions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementBuilderExtensions.cs
@@ -48,6 +48,21 @@ namespace Microsoft.FeatureManagement
         /// <exception cref="InvalidOperationException">Thrown if a variant service of the type has already been added.</exception>
         public static IFeatureManagementBuilder WithVariantService<TService>(this IFeatureManagementBuilder builder, string featureName) where TService : class
         {
+            return WithVariantService<TService>(builder, featureName, VariantServiceMatch.Variant);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="VariantServiceProvider{TService}"/> to the feature management system that selects the implementation
+        /// by either the assigned variant name or the enabled status of the feature flag.
+        /// </summary>
+        /// <param name="builder">The <see cref="IFeatureManagementBuilder"/> used to customize feature management functionality.</param>
+        /// <param name="featureName">The feature flag that should be used to determine which implementation of the service should be used.</param>
+        /// <param name="matchMode">Describes whether the implementation is matched by variant name or by feature flag status.</param>
+        /// <returns>A <see cref="IFeatureManagementBuilder"/> that can be used to customize feature management functionality.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if feature name parameter is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if a variant service of the type has already been added.</exception>
+        public static IFeatureManagementBuilder WithVariantService<TService>(this IFeatureManagementBuilder builder, string featureName, VariantServiceMatch matchMode) where TService : class
+        {
             if (string.IsNullOrEmpty(featureName))
             {
                 throw new ArgumentNullException(nameof(featureName));
@@ -63,14 +78,16 @@ namespace Microsoft.FeatureManagement
                 builder.Services.AddScoped<IVariantServiceProvider<TService>>(sp => new VariantServiceProvider<TService>(
                     featureName,
                     sp.GetRequiredService<IVariantFeatureManager>(),
-                    sp));
+                    sp,
+                    matchMode));
             }
             else
             {
                 builder.Services.AddSingleton<IVariantServiceProvider<TService>>(sp => new VariantServiceProvider<TService>(
                     featureName,
                     sp.GetRequiredService<IVariantFeatureManager>(),
-                    sp));
+                    sp,
+                    matchMode));
             }
 
             return builder;

--- a/src/Microsoft.FeatureManagement/FeatureManagementBuilderExtensions.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagementBuilderExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.FeatureManagement
         /// <exception cref="InvalidOperationException">Thrown if a variant service of the type has already been added.</exception>
         public static IFeatureManagementBuilder WithVariantService<TService>(this IFeatureManagementBuilder builder, string featureName) where TService : class
         {
-            return WithVariantService<TService>(builder, featureName, VariantServiceMatch.Variant);
+            return WithVariantService<TService>(builder, featureName, VariantServiceMatchMode.Variant);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Microsoft.FeatureManagement
         /// <returns>A <see cref="IFeatureManagementBuilder"/> that can be used to customize feature management functionality.</returns>
         /// <exception cref="ArgumentNullException">Thrown if feature name parameter is null.</exception>
         /// <exception cref="InvalidOperationException">Thrown if a variant service of the type has already been added.</exception>
-        public static IFeatureManagementBuilder WithVariantService<TService>(this IFeatureManagementBuilder builder, string featureName, VariantServiceMatch matchMode) where TService : class
+        public static IFeatureManagementBuilder WithVariantService<TService>(this IFeatureManagementBuilder builder, string featureName, VariantServiceMatchMode matchMode) where TService : class
         {
             if (string.IsNullOrEmpty(featureName))
             {

--- a/src/Microsoft.FeatureManagement/VariantServiceAliasAttribute.cs
+++ b/src/Microsoft.FeatureManagement/VariantServiceAliasAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
 using System;
@@ -23,7 +23,7 @@ namespace Microsoft.FeatureManagement
             }
 
             Alias = alias;
-            MatchMode = VariantServiceMatch.Variant;
+            MatchMode = VariantServiceMatchMode.Variant;
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Microsoft.FeatureManagement
         public VariantServiceAliasAttribute(bool enabled)
         {
             Alias = enabled ? bool.TrueString : bool.FalseString;
-            MatchMode = VariantServiceMatch.Status;
+            MatchMode = VariantServiceMatchMode.Status;
         }
 
         /// <summary>
@@ -44,6 +44,6 @@ namespace Microsoft.FeatureManagement
         /// <summary>
         /// Describes whether the implementation is matched by variant name or by feature flag status.
         /// </summary>
-        public VariantServiceMatch MatchMode { get; }
+        public VariantServiceMatchMode MatchMode { get; }
     }
 }

--- a/src/Microsoft.FeatureManagement/VariantServiceAliasAttribute.cs
+++ b/src/Microsoft.FeatureManagement/VariantServiceAliasAttribute.cs
@@ -6,14 +6,15 @@ using System;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// Allows the name of a variant service to be customized to relate to the variant name specified in configuration.
+    /// Allows a variant service implementation to be associated with either the assigned variant name
+    /// or the enabled status of the bound feature flag.
     /// </summary>
     public class VariantServiceAliasAttribute : Attribute
     {
         /// <summary>
-        /// Creates a variant service alias using the provided alias.
+        /// Creates a variant service alias that matches the assigned variant name of the feature flag.
         /// </summary>
-        /// <param name="alias">The alias of the variant service.</param>
+        /// <param name="alias">The alias of the variant service. Used to match the assigned variant name specified in the configuration.</param>
         public VariantServiceAliasAttribute(string alias)
         {
             if (string.IsNullOrEmpty(alias))
@@ -22,11 +23,27 @@ namespace Microsoft.FeatureManagement
             }
 
             Alias = alias;
+            MatchMode = VariantServiceMatch.Variant;
         }
 
         /// <summary>
-        /// The name that will be used to match variant name specified in the configuration.
+        /// Creates a variant service alias that matches the enabled status of the feature flag.
+        /// </summary>
+        /// <param name="enabled">Whether the variant service should be selected when the feature flag is enabled (<c>true</c>) or disabled (<c>false</c>).</param>
+        public VariantServiceAliasAttribute(bool enabled)
+        {
+            Alias = enabled ? bool.TrueString : bool.FalseString;
+            MatchMode = VariantServiceMatch.Status;
+        }
+
+        /// <summary>
+        /// The name that will be used to match either the assigned variant name or the enabled status of the feature flag.
         /// </summary>
         public string Alias { get; }
+
+        /// <summary>
+        /// Describes whether the implementation is matched by variant name or by feature flag status.
+        /// </summary>
+        public VariantServiceMatch MatchMode { get; }
     }
 }

--- a/src/Microsoft.FeatureManagement/VariantServiceMatch.cs
+++ b/src/Microsoft.FeatureManagement/VariantServiceMatch.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Describes how a variant service implementation is selected from the bound feature flag.
+    /// </summary>
+    public enum VariantServiceMatch
+    {
+        /// <summary>
+        /// The implementation is selected based on the assigned variant name of the feature flag.
+        /// </summary>
+        Variant = 0,
+
+        /// <summary>
+        /// The implementation is selected based on the enabled status of the feature flag.
+        /// </summary>
+        Status = 1
+    }
+}

--- a/src/Microsoft.FeatureManagement/VariantServiceMatchMode.cs
+++ b/src/Microsoft.FeatureManagement/VariantServiceMatchMode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.FeatureManagement
     /// <summary>
     /// Describes how a variant service implementation is selected from the bound feature flag.
     /// </summary>
-    public enum VariantServiceMatch
+    public enum VariantServiceMatchMode
     {
         /// <summary>
         /// The implementation is selected based on the assigned variant name of the feature flag.

--- a/src/Microsoft.FeatureManagement/VariantServiceProvider.cs
+++ b/src/Microsoft.FeatureManagement/VariantServiceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
 using Microsoft.Extensions.DependencyInjection;
@@ -13,17 +13,18 @@ using System.Threading.Tasks;
 namespace Microsoft.FeatureManagement
 {
     /// <summary>
-    /// Used to get different implementations of TService depending on the assigned variant from a specific variant feature flag.
+    /// Used to get different implementations of TService depending on either the assigned variant or the enabled status of a feature flag.
     /// </summary>
     internal class VariantServiceProvider<TService> : IVariantServiceProvider<TService> where TService : class
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly IVariantFeatureManager _featureManager;
         private readonly string _featureName;
+        private readonly VariantServiceMatch _matchMode;
         private readonly ConcurrentDictionary<string, TService> _variantServiceCache;
 
         /// <summary>
-        /// Creates a variant service provider.
+        /// Creates a variant service provider that selects an implementation based on the assigned variant of the feature flag.
         /// </summary>
         /// <param name="featureName">The feature flag that should be used to determine which variant of the service should be used.</param>
         /// <param name="featureManager">The feature manager to get the assigned variant of the feature flag.</param>
@@ -32,37 +33,62 @@ namespace Microsoft.FeatureManagement
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureManager"/> is null.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="serviceProvider"/> is null.</exception>
         public VariantServiceProvider(string featureName, IVariantFeatureManager featureManager, IServiceProvider serviceProvider)
+            : this(featureName, featureManager, serviceProvider, VariantServiceMatch.Variant)
+        {
+        }
+
+        /// <summary>
+        /// Creates a variant service provider that selects an implementation based on the assigned variant or the enabled status of the feature flag.
+        /// </summary>
+        /// <param name="featureName">The feature flag that should be used to determine which variant of the service should be used.</param>
+        /// <param name="featureManager">The feature manager to evaluate the feature flag.</param>
+        /// <param name="serviceProvider">The service provider used to resolve implementation variants of TService.</param>
+        /// <param name="matchMode">Describes whether the implementation is matched by variant name or by feature flag status.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureName"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureManager"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="serviceProvider"/> is null.</exception>
+        public VariantServiceProvider(string featureName, IVariantFeatureManager featureManager, IServiceProvider serviceProvider, VariantServiceMatch matchMode)
         {
             _featureName = featureName ?? throw new ArgumentNullException(nameof(featureName));
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _matchMode = matchMode;
             _variantServiceCache = new ConcurrentDictionary<string, TService>();
         }
 
         /// <summary>
-        /// Gets implementation of TService according to the assigned variant from the feature flag.
+        /// Gets the implementation of TService matched against the assigned variant or the enabled status of the feature flag.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-        /// <returns>An implementation matched with the assigned variant. If there is no matched implementation, it will return null.</returns>
+        /// <returns>An implementation matched with the assigned variant or status. If there is no matched implementation, it will return null.</returns>
         public async ValueTask<TService> GetServiceAsync(CancellationToken cancellationToken)
         {
             Debug.Assert(_featureName != null);
 
-            Variant variant = await _featureManager.GetVariantAsync(_featureName, cancellationToken);
-
-            TService implementation = null;
-
-            if (variant != null)
+            if (_matchMode == VariantServiceMatch.Status)
             {
-                implementation = _variantServiceCache.GetOrAdd(
-                    variant.Name,
-                    (variantName) => ResolveVariantService(variantName));
+                bool isEnabled = await _featureManager.IsEnabledAsync(_featureName, cancellationToken);
+
+                string statusKey = isEnabled ? bool.TrueString : bool.FalseString;
+
+                return _variantServiceCache.GetOrAdd(
+                    statusKey,
+                    (_) => ResolveByStatus(isEnabled));
             }
 
-            return implementation;
+            Variant variant = await _featureManager.GetVariantAsync(_featureName, cancellationToken);
+
+            if (variant == null)
+            {
+                return null;
+            }
+
+            return _variantServiceCache.GetOrAdd(
+                variant.Name,
+                (variantName) => ResolveByVariant(variantName));
         }
 
-        private TService ResolveVariantService(string variantName)
+        private TService ResolveByVariant(string variantName)
         {
             if (_serviceProvider is IKeyedServiceProvider)
             {
@@ -80,16 +106,54 @@ namespace Microsoft.FeatureManagement
                 service => IsMatchingVariantName(service.GetType(), variantName));
         }
 
-        private bool IsMatchingVariantName(Type implementationType, string variantName)
+        private TService ResolveByStatus(bool enabled)
         {
-            string implementationName = ((VariantServiceAliasAttribute)Attribute.GetCustomAttribute(implementationType, typeof(VariantServiceAliasAttribute)))?.Alias;
-
-            if (implementationName == null)
+            if (_serviceProvider is IKeyedServiceProvider)
             {
-                implementationName = implementationType.Name;
+                TService keyedService = _serviceProvider.GetKeyedService<TService>(enabled);
+
+                if (keyedService != null)
+                {
+                    return keyedService;
+                }
             }
 
+            IEnumerable<TService> services = _serviceProvider.GetRequiredService<IEnumerable<TService>>();
+
+            return services.FirstOrDefault(
+                service => IsMatchingStatus(service.GetType(), enabled));
+        }
+
+        private static bool IsMatchingVariantName(Type implementationType, string variantName)
+        {
+            var attribute = (VariantServiceAliasAttribute)Attribute.GetCustomAttribute(implementationType, typeof(VariantServiceAliasAttribute));
+
+            //
+            // Implementations explicitly declared as status-bound do not participate in variant-name matching.
+            if (attribute != null && attribute.MatchMode == VariantServiceMatch.Status)
+            {
+                return false;
+            }
+
+            string implementationName = attribute?.Alias ?? implementationType.Name;
+
             return string.Equals(implementationName, variantName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsMatchingStatus(Type implementationType, bool enabled)
+        {
+            var attribute = (VariantServiceAliasAttribute)Attribute.GetCustomAttribute(implementationType, typeof(VariantServiceAliasAttribute));
+
+            //
+            // Only implementations explicitly declared as status-bound participate in status matching.
+            if (attribute == null || attribute.MatchMode != VariantServiceMatch.Status)
+            {
+                return false;
+            }
+
+            string expected = enabled ? bool.TrueString : bool.FalseString;
+
+            return string.Equals(attribute.Alias, expected, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.FeatureManagement/VariantServiceProvider.cs
+++ b/src/Microsoft.FeatureManagement/VariantServiceProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.FeatureManagement
         private readonly IServiceProvider _serviceProvider;
         private readonly IVariantFeatureManager _featureManager;
         private readonly string _featureName;
-        private readonly VariantServiceMatch _matchMode;
+        private readonly VariantServiceMatchMode _matchMode;
         private readonly ConcurrentDictionary<string, TService> _variantServiceCache;
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Microsoft.FeatureManagement
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureManager"/> is null.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="serviceProvider"/> is null.</exception>
         public VariantServiceProvider(string featureName, IVariantFeatureManager featureManager, IServiceProvider serviceProvider)
-            : this(featureName, featureManager, serviceProvider, VariantServiceMatch.Variant)
+            : this(featureName, featureManager, serviceProvider, VariantServiceMatchMode.Variant)
         {
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.FeatureManagement
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureName"/> is null.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="featureManager"/> is null.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="serviceProvider"/> is null.</exception>
-        public VariantServiceProvider(string featureName, IVariantFeatureManager featureManager, IServiceProvider serviceProvider, VariantServiceMatch matchMode)
+        public VariantServiceProvider(string featureName, IVariantFeatureManager featureManager, IServiceProvider serviceProvider, VariantServiceMatchMode matchMode)
         {
             _featureName = featureName ?? throw new ArgumentNullException(nameof(featureName));
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
@@ -65,7 +65,7 @@ namespace Microsoft.FeatureManagement
         {
             Debug.Assert(_featureName != null);
 
-            if (_matchMode == VariantServiceMatch.Status)
+            if (_matchMode == VariantServiceMatchMode.Status)
             {
                 bool isEnabled = await _featureManager.IsEnabledAsync(_featureName, cancellationToken);
 
@@ -130,7 +130,7 @@ namespace Microsoft.FeatureManagement
 
             //
             // Implementations explicitly declared as status-bound do not participate in variant-name matching.
-            if (attribute != null && attribute.MatchMode == VariantServiceMatch.Status)
+            if (attribute != null && attribute.MatchMode == VariantServiceMatchMode.Status)
             {
                 return false;
             }
@@ -146,7 +146,7 @@ namespace Microsoft.FeatureManagement
 
             //
             // Only implementations explicitly declared as status-bound participate in status matching.
-            if (attribute == null || attribute.MatchMode != VariantServiceMatch.Status)
+            if (attribute == null || attribute.MatchMode != VariantServiceMatchMode.Status)
             {
                 return false;
             }

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -2399,7 +2399,7 @@ namespace Tests.FeatureManagement
 
             enabledServices.AddSingleton(configuration)
                 .AddFeatureManagement()
-                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatch.Status);
+                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatchMode.Status);
 
             ServiceProvider enabledServiceProvider = enabledServices.BuildServiceProvider();
 
@@ -2416,7 +2416,7 @@ namespace Tests.FeatureManagement
 
             disabledServices.AddSingleton(configuration)
                 .AddFeatureManagement()
-                .WithVariantService<IAlgorithm>(Features.OffTestFeature, VariantServiceMatch.Status);
+                .WithVariantService<IAlgorithm>(Features.OffTestFeature, VariantServiceMatchMode.Status);
 
             ServiceProvider disabledServiceProvider = disabledServices.BuildServiceProvider();
 
@@ -2443,7 +2443,7 @@ namespace Tests.FeatureManagement
 
             enabledServices.AddSingleton(configuration)
                 .AddFeatureManagement()
-                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatch.Status);
+                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatchMode.Status);
 
             ServiceProvider enabledServiceProvider = enabledServices.BuildServiceProvider();
 
@@ -2459,7 +2459,7 @@ namespace Tests.FeatureManagement
 
             disabledServices.AddSingleton(configuration)
                 .AddFeatureManagement()
-                .WithVariantService<IAlgorithm>(Features.OffTestFeature, VariantServiceMatch.Status);
+                .WithVariantService<IAlgorithm>(Features.OffTestFeature, VariantServiceMatchMode.Status);
 
             ServiceProvider disabledServiceProvider = disabledServices.BuildServiceProvider();
 
@@ -2485,7 +2485,7 @@ namespace Tests.FeatureManagement
 
             services.AddSingleton(configuration)
                 .AddFeatureManagement()
-                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatch.Status);
+                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatchMode.Status);
 
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 

--- a/tests/Tests.FeatureManagement/FeatureManagementTest.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagementTest.cs
@@ -2386,6 +2386,116 @@ namespace Tests.FeatureManagement
         }
 
         [Fact]
+        public async Task VariantServiceProviderResolvesByFlagStatusWithKeyedServices()
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            IServiceCollection enabledServices = new ServiceCollection();
+
+            enabledServices.AddKeyedSingleton<IAlgorithm, EnabledAlgorithm>(true);
+            enabledServices.AddKeyedSingleton<IAlgorithm, DisabledAlgorithm>(false);
+
+            enabledServices.AddSingleton(configuration)
+                .AddFeatureManagement()
+                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatch.Status);
+
+            ServiceProvider enabledServiceProvider = enabledServices.BuildServiceProvider();
+
+            IVariantServiceProvider<IAlgorithm> enabledFeaturedAlgorithm = enabledServiceProvider.GetRequiredService<IVariantServiceProvider<IAlgorithm>>();
+
+            IAlgorithm algorithm = await enabledFeaturedAlgorithm.GetServiceAsync(CancellationToken.None);
+            Assert.NotNull(algorithm);
+            Assert.Equal("Enabled", algorithm.Style);
+
+            IServiceCollection disabledServices = new ServiceCollection();
+
+            disabledServices.AddKeyedSingleton<IAlgorithm, EnabledAlgorithm>(true);
+            disabledServices.AddKeyedSingleton<IAlgorithm, DisabledAlgorithm>(false);
+
+            disabledServices.AddSingleton(configuration)
+                .AddFeatureManagement()
+                .WithVariantService<IAlgorithm>(Features.OffTestFeature, VariantServiceMatch.Status);
+
+            ServiceProvider disabledServiceProvider = disabledServices.BuildServiceProvider();
+
+            IVariantServiceProvider<IAlgorithm> disabledFeaturedAlgorithm = disabledServiceProvider.GetRequiredService<IVariantServiceProvider<IAlgorithm>>();
+
+            algorithm = await disabledFeaturedAlgorithm.GetServiceAsync(CancellationToken.None);
+            Assert.NotNull(algorithm);
+            Assert.Equal("Disabled", algorithm.Style);
+        }
+
+        [Fact]
+        public async Task VariantServiceProviderResolvesByFlagStatusWithAliasAttribute()
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            IServiceCollection enabledServices = new ServiceCollection();
+
+            //
+            // Non-keyed registrations; matching relies on [VariantServiceAlias(bool)] attributes.
+            enabledServices.AddSingleton<IAlgorithm, EnabledAlgorithm>();
+            enabledServices.AddSingleton<IAlgorithm, DisabledAlgorithm>();
+
+            enabledServices.AddSingleton(configuration)
+                .AddFeatureManagement()
+                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatch.Status);
+
+            ServiceProvider enabledServiceProvider = enabledServices.BuildServiceProvider();
+
+            IAlgorithm algorithm = await enabledServiceProvider.GetRequiredService<IVariantServiceProvider<IAlgorithm>>()
+                .GetServiceAsync(CancellationToken.None);
+            Assert.NotNull(algorithm);
+            Assert.Equal("Enabled", algorithm.Style);
+
+            IServiceCollection disabledServices = new ServiceCollection();
+
+            disabledServices.AddSingleton<IAlgorithm, EnabledAlgorithm>();
+            disabledServices.AddSingleton<IAlgorithm, DisabledAlgorithm>();
+
+            disabledServices.AddSingleton(configuration)
+                .AddFeatureManagement()
+                .WithVariantService<IAlgorithm>(Features.OffTestFeature, VariantServiceMatch.Status);
+
+            ServiceProvider disabledServiceProvider = disabledServices.BuildServiceProvider();
+
+            algorithm = await disabledServiceProvider.GetRequiredService<IVariantServiceProvider<IAlgorithm>>()
+                .GetServiceAsync(CancellationToken.None);
+            Assert.NotNull(algorithm);
+            Assert.Equal("Disabled", algorithm.Style);
+        }
+
+        [Fact]
+        public async Task VariantServiceProviderStatusModeIgnoresVariantBoundImplementations()
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            IServiceCollection services = new ServiceCollection();
+
+            //
+            // Only variant-bound implementations registered; none of them should match in Status mode.
+            services.AddSingleton<IAlgorithm, AlgorithmBeta>();
+            services.AddSingleton<IAlgorithm, AlgorithmSigma>();
+
+            services.AddSingleton(configuration)
+                .AddFeatureManagement()
+                .WithVariantService<IAlgorithm>(Features.OnTestFeature, VariantServiceMatch.Status);
+
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IAlgorithm algorithm = await serviceProvider.GetRequiredService<IVariantServiceProvider<IAlgorithm>>()
+                .GetServiceAsync(CancellationToken.None);
+
+            Assert.Null(algorithm);
+        }
+
+        [Fact]
         public async Task VariantFeatureFlagWithContextualFeatureFilter()
         {
             IConfiguration configuration = new ConfigurationBuilder()

--- a/tests/Tests.FeatureManagement/VariantServices.cs
+++ b/tests/Tests.FeatureManagement/VariantServices.cs
@@ -37,4 +37,16 @@ namespace Tests.FeatureManagement
             Style = style;
         }
     }
+
+    [VariantServiceAlias(true)]
+    class EnabledAlgorithm : IAlgorithm
+    {
+        public string Style { get; } = "Enabled";
+    }
+
+    [VariantServiceAlias(false)]
+    class DisabledAlgorithm : IAlgorithm
+    {
+        public string Style { get; } = "Disabled";
+    }
 }


### PR DESCRIPTION
## Why this PR?

A follow up PR for #606, trying to resolve #604

Today `VariantServiceProvider<T>` only selects an implementation based on the assigned variant name. This PR adds an alternative mode where the implementation is selected based on the feature flag's enabled status (true/false), useful when a feature has no variants (e.g. a simple toggle flag).

Introduce `VariantServiceMatchMode` enum which has `Variant` (default) and `Status` value.

Usage:

```C#
// Service implementations
[VariantServiceAlias(true)]
public class EnabledCalculator : ICalculator { /* ... */ }

[VariantServiceAlias(false)]
public class DisabledCalculator : ICalculator { /* ... */ }

// Registration (keyed for lazy instantiation)
services.AddKeyedSingleton<ICalculator, EnabledCalculator>(true);
services.AddKeyedSingleton<ICalculator, DisabledCalculator>(false);

// Or normal registration
// services.AddSingleton<ICalculator, EnabledCalculator>();
// services.AddSingleton<ICalculator, DisabledCalculator>();

services.AddFeatureManagement()
    .WithVariantService<ICalculator>("AdvancedMath", VariantServiceMatchMode.Status);
```
Note that the `AddKeyed*` family takes object? serviceKey, not just string.
<img width="837" height="258" alt="image" src="https://github.com/user-attachments/assets/0d2b6f6d-e0be-450c-a0e9-d430edfb11a4" />
